### PR TITLE
return appropriate error codes on result failures

### DIFF
--- a/src/polyswarm/hunt.py
+++ b/src/polyswarm/hunt.py
@@ -23,10 +23,13 @@ def live_start(ctx, rule_file):
     rules = rule_file.read()
 
     try:
-        output.hunt_submission(api.live(rules))
+        result = api.live(rules)
+        output.hunt_submission(result)
+        if result.failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
-        sys.exit(1)
+        sys.exit(2)
     except exceptions.InvalidYaraRules as e:
         output.invalid_rule(e)
         sys.exit(2)
@@ -40,10 +43,14 @@ def live_delete(ctx, hunt_id):
     output = ctx.obj['output']
 
     try:
-        output.hunt_deletion(api.live_delete(hunt_id))
+        result = api.live_delete(hunt_id)
+        output.hunt_deletion(result)
+
+        if result.failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
-        sys.exit(1)
+        sys.exit(2)
 
 
 @live.command('list', short_help='List all live hunts performed')
@@ -53,10 +60,13 @@ def live_list(ctx):
     output = ctx.obj['output']
 
     try:
-        output.hunt_list(api.live_list())
+        result = api.live_list()
+        output.hunt_list(result)
+        if result.failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
-        sys.exit(1)
+        sys.exit(2)
 
 
 @click.option('-i', '--hunt-id', type=int, help='ID of the rule file (defaults to latest)')
@@ -76,6 +86,8 @@ def live_results(ctx, hunt_id, without_metadata, without_bounties, since):
         result = api.live_results(hunt_id, with_metadata=not without_metadata, with_instances=not without_bounties,
                                   since=since)
         output.hunt_result(result)
+        if result.failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
         sys.exit(1)
@@ -91,10 +103,14 @@ def historical_start(ctx, rule_file):
     rules = rule_file.read()
 
     try:
-        output.hunt_submission(api.historical(rules))
+        result = api.historical(rules)
+        output.hunt_submission(result)
+
+        if result.failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
-        sys.exit(1)
+        sys.exit(2)
     except exceptions.InvalidYaraRules as e:
         output.invalid_rule(e)
         sys.exit(2)
@@ -108,10 +124,14 @@ def historical_delete(ctx, hunt_id):
     output = ctx.obj['output']
 
     try:
-        output.hunt_deletion(api.historical_delete(hunt_id))
+        result = api.historical_delete(hunt_id)
+        output.hunt_deletion(result)
+
+        if result.failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
-        sys.exit(1)
+        sys.exit(2)
 
 
 @historical.command('list', short_help='List all historical hunts performed')
@@ -121,10 +141,14 @@ def historical_list(ctx):
     output = ctx.obj['output']
 
     try:
-        output.hunt_list(api.historical_list())
+        result = api.historical_list()
+        output.hunt_list(result)
+
+        if result.failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
-        sys.exit(1)
+        sys.exit(2)
 
 
 @click.option('-i', '--hunt-id', type=int, help='ID of the rule file (defaults to latest)')
@@ -145,6 +169,9 @@ def historical_results(ctx, hunt_id, without_metadata, without_bounties, since):
                                         since=since)
 
         output.hunt_result(result)
+
+        if result.failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
-        sys.exit(1)
+        sys.exit(2)

--- a/src/polyswarm/scan.py
+++ b/src/polyswarm/scan.py
@@ -37,15 +37,22 @@ def scan(ctx, path, force, recursive, timeout):
             logger.warning('Path %s is neither a file nor a directory, ignoring.', path)
 
     try:
+        any_failed = False
         for result in api.scan(*files):
             output.scan_result(result)
+            any_failed = result.failed or any_failed
 
         for d in directories:
             for result in api.scan_directory(d, recursive=recursive):
                 output.scan_result(result)
+                any_failed = result.failed or any_failed
+
+        if any_failed:
+            sys.exit(1)
+
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
-        sys.exit(1)
+        sys.exit(2)
 
 
 @click.option('-r', '--url-file', help='File of URLs, one per line.', type=click.File('r'))
@@ -69,11 +76,16 @@ def url_scan(ctx, url, url_file, force, timeout):
         urls.extend([u.strip() for u in url_file.readlines()])
 
     try:
+        any_failed = False
         for result in api.scan_urls(*urls):
-           output.scan_result(result)
+            output.scan_result(result)
+            any_failed = result.failed or any_failed
+
+        if any_failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
-        sys.exit(1)
+        sys.exit(2)
 
 
 @click.option('-r', '--hash-file', help='File of hashes, one per line.', type=click.File('r'))
@@ -91,11 +103,15 @@ def rescan(ctx, hash_file, hash_type, hash):
     hashes = parse_hashes(hash, hash_type, hash_file)
 
     if hashes:
+        any_failed = False
         try:
             for result in api.rescan(*hashes):
                 output.scan_result(result)
+                any_failed = result.failed or any_failed
         except exceptions.UsageLimitsExceeded:
             output.usage_exceeded()
+            sys.exit(1)
+        if any_failed:
             sys.exit(1)
     else:
         raise click.BadParameter('Hash not valid, must be sha256|md5|sha1 in hexadecimal format')
@@ -124,8 +140,12 @@ def lookup(ctx, uuid, uuid_file):
                 logger.warning('Invalid uuid %s in file, ignoring.', u)
 
     try:
+        any_failed = False
         for result in api.lookup(*uuids):
             output.scan_result(result)
+            any_failed = result.failed or any_failed
+        if any_failed:
+            sys.exit(1)
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
         sys.exit(1)

--- a/src/polyswarm/search.py
+++ b/src/polyswarm/search.py
@@ -36,8 +36,14 @@ def hashes(ctx, hashes, hash_file, hash_type, without_metadata, without_bounties
             results = api.search(*hashes, with_instances=not without_bounties, with_metadata=not without_metadata)
 
             # for json, this is effectively jsonlines
+            all_failed = True
             for result in results:
                 output.search_result(result)
+                if not result.failed:
+                    all_failed = False
+
+            if all_failed:
+                sys.exit(1)
         else:
             raise click.BadParameter('Hash not valid, must be sha256|md5|sha1 in hexadecimal format')
     except exceptions.UsageLimitsExceeded:
@@ -75,9 +81,16 @@ def metadata(ctx, query_string, query_file, without_metadata, without_bounties):
         return 0
 
     try:
+        all_failed = True
         for result in api.search_by_metadata(*queries, with_instances=not without_bounties,
                                              with_metadata=not without_metadata):
             output.search_result(result)
+            if not result.failed:
+                all_failed = False
+
     except exceptions.UsageLimitsExceeded:
         output.usage_exceeded()
+        sys.exit(2)
+
+    if all_failed:
         sys.exit(1)


### PR DESCRIPTION
Handle soft failures (like not getting any results) and return appropriate bash error codes. Requires https://github.com/polyswarm/polyswarm-api/pull/77