### PR TITLE
support --no-color in pretty-json

### DIFF
--- a/src/polyswarm/formatters/json.py
+++ b/src/polyswarm/formatters/json.py
@@ -47,7 +47,13 @@ class JSONOutput(base.BaseOutput):
 
 class PrettyJSONOutput(JSONOutput):
     name = 'pretty-json'
-    @staticmethod
-    def _to_json(json_data):
+
+    def __init__(self, output, color, **kwargs):
+        super(PrettyJSONOutput, self).__init__(output, **kwargs)
+        self.color = color
+
+    def _to_json(self, json_data):
         formatted_json = json.dumps(json_data, indent=4, sort_keys=True)
+        if not self.color:
+            return formatted_json
         return highlight(formatted_json, JsonLexer(), TerminalTrueColorFormatter(style='monokai'))


### PR DESCRIPTION
Supports `--no-color` option with `--fmt pretty-json`. See DN-3985 for context.