### PR TITLE
parsing color option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ click-log==0.3.2
 pygments==2.5.2
 mock==3.0.4
 responses==0.10.6
+colorama~=0.4.3

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=[
         'polyswarm-api>=2.1.2<3',
         'click~=7.0',
+        'colorama~=0.4.3',
         'future~=0.18.2',
         'click-log~=0.3.2',
         'pygments~=2.5.2',

--- a/src/polyswarm/client/polyswarm.py
+++ b/src/polyswarm/client/polyswarm.py
@@ -102,17 +102,6 @@ class ExceptionHandlingGroup(click.Group):
             raise Exit(2)
 
 
-def support_color(color, output_file):
-    is_a_tty = hasattr(output_file, 'isatty') and output_file.isatty()
-    if not is_a_tty:
-        return False
-    if platform.system() == 'Windows' and 'ANSICON' not in os.environ:
-        if color:
-            logger.warning('Color is disabled because this Windows terminal does not support it.')
-        return False
-    return color
-
-
 @click.group(cls=ExceptionHandlingGroup, context_settings=CONTEXT_SETTINGS)
 @click.option('-a', '--api-key', help='Your API key for polyswarm.network (required).',
               default='', callback=validate_key, envvar='POLYSWARM_API_KEY')
@@ -142,7 +131,6 @@ def polyswarm(ctx, api_key, api_uri, output_file, output_format, color, verbose,
         return
 
     output_file = output_file or click.get_text_stream('stdout')
-    color = support_color(color, output_file)
 
     ctx.obj['api'] = Polyswarm(api_key, uri=api_uri, community=community, parallel=parallel)
     ctx.obj['output'] = formatters[output_format](color=color, output=output_file)

--- a/src/polyswarm/client/polyswarm.py
+++ b/src/polyswarm/client/polyswarm.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 import logging
-import platform
-import os
 try:
     from json import JSONDecodeError
 except ImportError:

--- a/src/polyswarm/client/polyswarm.py
+++ b/src/polyswarm/client/polyswarm.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 import logging
+import platform
+import os
 try:
     from json import JSONDecodeError
 except ImportError:
@@ -15,16 +17,16 @@ from polyswarm_api import exceptions as api_exceptions
 from polyswarm import exceptions
 from polyswarm.polyswarm import Polyswarm
 from polyswarm.formatters import formatters
-from .utils import validate_key
-from .hunt import live, historical
-from .scan import scan, lookup, wait, rescan, rescan_id
-from .download import download, cat, stream
-from .search import search
-from .rules import rules
-from .links import link
-from .tags import tag
-from .families import family
-from .metadata import metadata
+from polyswarm.client.utils import validate_key
+from polyswarm.client.hunt import live, historical
+from polyswarm.client.scan import scan, lookup, wait, rescan, rescan_id
+from polyswarm.client.download import download, cat, stream
+from polyswarm.client.search import search
+from polyswarm.client.rules import rules
+from polyswarm.client.links import link
+from polyswarm.client.tags import tag
+from polyswarm.client.families import family
+from polyswarm.client.metadata import metadata
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +102,14 @@ class ExceptionHandlingGroup(click.Group):
             raise Exit(2)
 
 
+def support_color(color):
+    if platform.system() == 'Windows' and os.environ.get('TERM') != 'ANSI':
+        if color:
+            logger.warning('Color is disabled because this Windows terminal does not support it.')
+        return False
+    return color
+
+
 @click.group(cls=ExceptionHandlingGroup, context_settings=CONTEXT_SETTINGS)
 @click.option('-a', '--api-key', help='Your API key for polyswarm.network (required).',
               default='', callback=validate_key, envvar='POLYSWARM_API_KEY')
@@ -133,6 +143,8 @@ def polyswarm(ctx, api_key, api_uri, output_file, output_format, color, verbose,
         color = False
     else:
         output_file = click.get_text_stream('stdout')
+
+    color = support_color(color)
 
     ctx.obj['api'] = Polyswarm(api_key, uri=api_uri, community=community, parallel=parallel)
     ctx.obj['output'] = formatters[output_format](color=color, output=output_file)

--- a/src/polyswarm/formatters/hashes.py
+++ b/src/polyswarm/formatters/hashes.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import json
 
-from . import base
+import click
+
+from polyswarm.formatters import base
 
 
 logger = logging.getLogger(__name__)
@@ -16,14 +18,14 @@ class SHA256Output(base.BaseOutput):
         return json.dumps(result.json['result'])
 
     def artifact_instance(self, instance, timeout=False):
-        self.out.write(instance.sha256 + '\n')
+        click.secho(instance.sha256, file=self.out)
 
     def hunt_result(self, result):
-        self.out.write(result.artifact.sha256 + '\n')
+        click.secho(result.artifact, file=self.out)
 
     def metadata(self, result):
         if result.sha256:
-            self.out.write(result.sha256 + '\n')
+            click.secho(result.sha256, file=self.out)
         else:
             logger.warning('Could not render metadata as sha256, value is %s', result.sha256)
 
@@ -36,14 +38,14 @@ class SHA1Output(base.BaseOutput):
         return json.dumps(result.json['result'])
 
     def artifact_instance(self, result, timeout=False):
-        self.out.write(result.sha1 + '\n')
+        click.secho(result.sha1, file=self.out)
 
     def hunt_result(self, result):
-        self.out.write(result.artifact.sha1 + '\n')
+        click.secho(result.artifact, file=self.out)
 
     def metadata(self, result):
         if result.sha1:
-            self.out.write(result.sha1 + '\n')
+            click.secho(result.sha1, file=self.out)
         else:
             logger.warning('Could not render metadata as sha1, value is %s', result.sha1)
 
@@ -56,13 +58,13 @@ class MD5Output(base.BaseOutput):
         return json.dumps(result.json['result'])
 
     def artifact_instance(self, result, timeout=False):
-        self.out.write(result.md5 + '\n')
+        click.secho(result.md5, file=self.out)
 
     def hunt_result(self, result):
-        self.out.write(result.artifact.md5 + '\n')
+        click.secho(result.artifact, file=self.out)
 
     def metadata(self, result):
         if result.md5:
-            self.out.write(result.md5 + '\n')
+            click.secho(result.md5, file=self.out)
         else:
             logger.warning('Could not render metadata as md5, value is %s', result.md5)

--- a/src/polyswarm/formatters/hashes.py
+++ b/src/polyswarm/formatters/hashes.py
@@ -18,14 +18,14 @@ class SHA256Output(base.BaseOutput):
         return json.dumps(result.json['result'])
 
     def artifact_instance(self, instance, timeout=False):
-        click.secho(instance.sha256, file=self.out)
+        click.echo(instance.sha256, file=self.out)
 
     def hunt_result(self, result):
-        click.secho(result.artifact, file=self.out)
+        click.echo(result.artifact, file=self.out)
 
     def metadata(self, result):
         if result.sha256:
-            click.secho(result.sha256, file=self.out)
+            click.echo(result.sha256, file=self.out)
         else:
             logger.warning('Could not render metadata as sha256, value is %s', result.sha256)
 
@@ -38,14 +38,14 @@ class SHA1Output(base.BaseOutput):
         return json.dumps(result.json['result'])
 
     def artifact_instance(self, result, timeout=False):
-        click.secho(result.sha1, file=self.out)
+        click.echo(result.sha1, file=self.out)
 
     def hunt_result(self, result):
-        click.secho(result.artifact, file=self.out)
+        click.echo(result.artifact, file=self.out)
 
     def metadata(self, result):
         if result.sha1:
-            click.secho(result.sha1, file=self.out)
+            click.echo(result.sha1, file=self.out)
         else:
             logger.warning('Could not render metadata as sha1, value is %s', result.sha1)
 
@@ -58,13 +58,13 @@ class MD5Output(base.BaseOutput):
         return json.dumps(result.json['result'])
 
     def artifact_instance(self, result, timeout=False):
-        click.secho(result.md5, file=self.out)
+        click.echo(result.md5, file=self.out)
 
     def hunt_result(self, result):
-        click.secho(result.artifact, file=self.out)
+        click.echo(result.artifact, file=self.out)
 
     def metadata(self, result):
         if result.md5:
-            click.secho(result.md5, file=self.out)
+            click.echo(result.md5, file=self.out)
         else:
             logger.warning('Could not render metadata as md5, value is %s', result.md5)

--- a/src/polyswarm/formatters/json.py
+++ b/src/polyswarm/formatters/json.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 import json
+
+import click
 from pygments import highlight
 from pygments.lexers import JsonLexer
 from pygments.formatters import Terminal256Formatter
 
 
-from . import base
+from polyswarm.formatters import base
 
 
 class JSONOutput(base.BaseOutput):
@@ -15,35 +17,37 @@ class JSONOutput(base.BaseOutput):
         return json.dumps(json_data, sort_keys=True)
 
     def artifact_instance(self, result, timeout=False):
-        self.out.write(self._to_json(result.json) + '\n')
+        click.secho(self._to_json(result.json), file=self.out)
 
     def hunt_result(self, result):
-        self.out.write(self._to_json(result.json) + '\n')
+        click.secho(self._to_json(result.json), file=self.out)
 
     def hunt_deletion(self, result):
-        self.out.write(self._to_json(result.json) + '\n')
+        click.secho(self._to_json(result.json), file=self.out)
 
     def hunt(self, result):
-        self.out.write(self._to_json(result.json) + '\n')
+        click.secho(self._to_json(result.json), file=self.out)
 
     def local_artifact(self, artifact):
-        self.out.write(json.dumps(
-            {'hash': artifact.artifact_name, 'path': artifact.path}, sort_keys=True)+'\n')
+        click.secho(
+            json.dumps({'hash': artifact.artifact_name, 'path': artifact.path}, sort_keys=True),
+            file=self.out,
+        )
 
     def ruleset(self, result, contents=False):
-        self.out.write(self._to_json(result.json) + '\n')
+        click.secho(self._to_json(result.json), file=self.out)
 
     def metadata(self, result):
-        self.out.write(self._to_json(result.json) + '\n')
+        click.secho(self._to_json(result.json), file=self.out)
 
     def tag_link(self, result):
-        self.out.write(self._to_json(result.json) + '\n')
+        click.secho(self._to_json(result.json), file=self.out)
 
     def family(self, result):
-        self.out.write(self._to_json(result.json) + '\n')
+        click.secho(self._to_json(result.json), file=self.out)
 
     def tag(self, result):
-        self.out.write(self._to_json(result.json) + '\n')
+        click.secho(self._to_json(result.json), file=self.out)
 
 
 class PrettyJSONOutput(JSONOutput):

--- a/src/polyswarm/formatters/json.py
+++ b/src/polyswarm/formatters/json.py
@@ -17,37 +17,37 @@ class JSONOutput(base.BaseOutput):
         return json.dumps(json_data, sort_keys=True)
 
     def artifact_instance(self, result, timeout=False):
-        click.secho(self._to_json(result.json), file=self.out)
+        click.echo(self._to_json(result.json), file=self.out)
 
     def hunt_result(self, result):
-        click.secho(self._to_json(result.json), file=self.out)
+        click.echo(self._to_json(result.json), file=self.out)
 
     def hunt_deletion(self, result):
-        click.secho(self._to_json(result.json), file=self.out)
+        click.echo(self._to_json(result.json), file=self.out)
 
     def hunt(self, result):
-        click.secho(self._to_json(result.json), file=self.out)
+        click.echo(self._to_json(result.json), file=self.out)
 
     def local_artifact(self, artifact):
-        click.secho(
+        click.echo(
             json.dumps({'hash': artifact.artifact_name, 'path': artifact.path}, sort_keys=True),
             file=self.out,
         )
 
     def ruleset(self, result, contents=False):
-        click.secho(self._to_json(result.json), file=self.out)
+        click.echo(self._to_json(result.json), file=self.out)
 
     def metadata(self, result):
-        click.secho(self._to_json(result.json), file=self.out)
+        click.echo(self._to_json(result.json), file=self.out)
 
     def tag_link(self, result):
-        click.secho(self._to_json(result.json), file=self.out)
+        click.echo(self._to_json(result.json), file=self.out)
 
     def family(self, result):
-        click.secho(self._to_json(result.json), file=self.out)
+        click.echo(self._to_json(result.json), file=self.out)
 
     def tag(self, result):
-        click.secho(self._to_json(result.json), file=self.out)
+        click.echo(self._to_json(result.json), file=self.out)
 
 
 class PrettyJSONOutput(JSONOutput):

--- a/src/polyswarm/formatters/text.py
+++ b/src/polyswarm/formatters/text.py
@@ -2,27 +2,10 @@ from __future__ import absolute_import, unicode_literals
 import sys
 import functools
 import json
-from . import base
 
+import click
 
-# TODO rewrite some of this to be not terrible
-def is_colored(fn):
-    prefix, suffix = {
-                '_red': ('\033[91m', '\033[0m'),
-                '_yellow': ('\033[93m', '\033[0m'),
-                '_green': ('\033[92m', '\033[0m'),
-                '_white': ('', ''),
-                '_blue': ('\033[94m', '\033[0m'),
-                '_open_group': ('\033[94m', '\033[0m'),
-    }.get(fn.__name__, ('', ''))
-
-    @functools.wraps(fn)
-    def wrapper(self, text):
-        if self.color:
-            return prefix + fn(self, text) + suffix
-        else:
-            return fn(self, text)
-    return wrapper
+from polyswarm.formatters import base
 
 
 def is_grouped(fn):
@@ -52,7 +35,7 @@ class TextOutput(base.BaseOutput):
 
     def _output(self, output, write):
         if write:
-            self.out.write('\n'.join(output) + '\n\n')
+            click.echo('\n'.join(output) + '\n', file=self.out)
         else:
             return output
 
@@ -263,30 +246,25 @@ class TextOutput(base.BaseOutput):
         return self._output(output, write)
 
 
-    @is_colored
     @is_grouped
     def _white(self, text):
-        return '%s' % text
+        return click.style(text, fg='white')
 
-    @is_colored
     @is_grouped
     def _yellow(self, text):
-        return '%s' % text
+        return click.style(text, fg='yellow')
 
-    @is_colored
     @is_grouped
     def _red(self, text):
-        return '%s' % text
+        return click.style(text, fg='red')
 
-    @is_colored
     @is_grouped
     def _blue(self, text):
-        return '%s' % text
+        return click.style(text, fg='blue')
 
-    @is_colored
     @is_grouped
     def _green(self, text):
-        return '%s' % text
+        return click.style(text, fg='green')
 
     def _open_group(self):
         self._depth += 1

--- a/tests/utils/mock_polyswarm_api_results.py
+++ b/tests/utils/mock_polyswarm_api_results.py
@@ -32,10 +32,10 @@ def text_instances():
     values.append(
         """============================= Artifact Instance =============================
 Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
-[91mDetections: 1/1 engines reported malicious[0m
-[91m	eicar[0m: Malicious, metadata: {"malware_family": "Eicar Test File", "scanner": {"environment": {"architecture": "x86_64", "operating_system": "Linux"}}}
-[94mScan id: 49091542211453596[0m
-[94mSHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f[0m
+Detections: 1/1 engines reported malicious
+	eicar: Malicious, metadata: {"malware_family": "Eicar Test File", "scanner": {"environment": {"architecture": "x86_64", "operating_system": "Linux"}}}
+Scan id: 49091542211453596
+SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
 SHA1: 3395856ce81f2b7382dee72602f798b642f14140
 MD5: 44d88612fea8a8f36de82e1278abb02f
 File type: mimetype: text/plain, extended_info: EICAR virus test files
@@ -46,7 +46,7 @@ Status: Assertion window closed
 Filename: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
 Community: gamma
 Country: 
-[91mPolyScore: 0.50000000000000000000[0m
+PolyScore: 0.50000000000000000000
 
 """)
     return values
@@ -123,7 +123,7 @@ def text_metadata():
     values = []
     values.append(
         """============================= Metadata =============================
-[94mArtifact id: 19021969312842541[0m
+Artifact id: 19021969312842541
 Created: 2020-01-14 17:48:55.854940+00:00
 SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
 SHA1: 3395856ce81f2b7382dee72602f798b642f14140
@@ -178,10 +178,10 @@ def text_live_results():
         """Match on rule eicar_substring_test
 ============================= Artifact Instance =============================
 Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
-[91mDetections: 1/1 engines reported malicious[0m
-[91m	eicar[0m: Malicious, metadata: {"malware_family": "Eicar Test File", "scanner": {"environment": {"architecture": "x86_64", "operating_system": "Linux"}}}
-[94mScan id: 49091542211453596[0m
-[94mSHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f[0m
+Detections: 1/1 engines reported malicious
+	eicar: Malicious, metadata: {"malware_family": "Eicar Test File", "scanner": {"environment": {"architecture": "x86_64", "operating_system": "Linux"}}}
+Scan id: 49091542211453596
+SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
 SHA1: 3395856ce81f2b7382dee72602f798b642f14140
 MD5: 44d88612fea8a8f36de82e1278abb02f
 File type: mimetype: text/plain, extended_info: EICAR virus test files
@@ -192,7 +192,7 @@ Status: Assertion window closed
 Filename: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
 Community: gamma
 Country: 
-[91mPolyScore: 0.50000000000000000000[0m
+PolyScore: 0.50000000000000000000
 
 """)
     return values
@@ -230,10 +230,10 @@ def text_hisotrical_results():
         """Match on rule eicar_substring_test
 ============================= Artifact Instance =============================
 Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
-[91mDetections: 1/1 engines reported malicious[0m
-[91m	eicar[0m: Malicious, metadata: {"malware_family": "Eicar Test File", "scanner": {"environment": {"architecture": "x86_64", "operating_system": "Linux"}}}
-[94mScan id: 49091542211453596[0m
-[94mSHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f[0m
+Detections: 1/1 engines reported malicious
+	eicar: Malicious, metadata: {"malware_family": "Eicar Test File", "scanner": {"environment": {"architecture": "x86_64", "operating_system": "Linux"}}}
+Scan id: 49091542211453596
+SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
 SHA1: 3395856ce81f2b7382dee72602f798b642f14140
 MD5: 44d88612fea8a8f36de82e1278abb02f
 File type: mimetype: text/plain, extended_info: EICAR virus test files
@@ -244,7 +244,7 @@ Status: Assertion window closed
 Filename: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
 Community: gamma
 Country: 
-[91mPolyScore: 0.50000000000000000000[0m
+PolyScore: 0.50000000000000000000
 
 """)
     return values
@@ -262,7 +262,7 @@ def hunts(test):
 def text_hunts():
     values = []
     values.append(
-        """[94mHunt Id: 61210404295535902[0m
+        """Hunt Id: 61210404295535902
 Active: True
 Created at: 2019-11-13 16:27:45.013226
 
@@ -273,8 +273,8 @@ Created at: 2019-11-13 16:27:45.013226
 def text_detele_hunts():
     values = []
     values.append(
-        """[93mSuccessfully deleted Hunt:[0m
-[94mHunt Id: 61210404295535902[0m
+        """Successfully deleted Hunt:
+Hunt Id: 61210404295535902
 Active: True
 Created at: 2019-11-13 16:27:45.013226
 


### PR DESCRIPTION
- Using click facilities for outputting text, this makes it multi-platform by default
- Using custom `pygments` Formatter based on click (which uses a 16 color pallet), this ensures that json output will be colored properly even in Windows
- Adding `colorama` package so that it is Windows-compatible