### PR TITLE
DN6330 Adjust parameters to allow filtering by public/private when viewing live/historical results

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license='MIT',
     python_requires='>3.5,<4',
     install_requires=[
-        'polyswarm-api~=3.4.3.dev',
+        'polyswarm-api~=3.4.3',
         'click~=7.0',
         'colorama~=0.4.3',
         'future~=0.18.2',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license='MIT',
     python_requires='>3.5,<4',
     install_requires=[
-        'polyswarm-api~=3.4.0',
+        'polyswarm-api~=3.4.3.dev',
         'click~=7.0',
         'colorama~=0.4.3',
         'future~=0.18.2',

--- a/src/polyswarm/client/historical.py
+++ b/src/polyswarm/client/historical.py
@@ -94,13 +94,14 @@ def historical_delete_list(ctx, historical_ids):
 @click.option('-f', '--family', help='Filter hunt results based on the family name.')
 @click.option('-l', '--polyscore-lower', help='Polyscore lower bound for the hunt results.')
 @click.option('-u', '--polyscore-upper', help='Polyscore upper bound for the hunt results.')
+@click.option('-p', '--private', is_flag=True, help='Filter results to only your private community.')
 @click.pass_context
-def historical_results(ctx, hunt_id, rule_name, family, polyscore_lower, polyscore_upper):
+def historical_results(ctx, hunt_id, rule_name, family, polyscore_lower, polyscore_upper, private):
     api = ctx.obj['api']
     output = ctx.obj['output']
     for result in api.historical_results_multiple(
             hunt_id, rule_name=rule_name, family=family,
-            polyscore_lower=polyscore_lower, polyscore_upper=polyscore_upper):
+            polyscore_lower=polyscore_lower, polyscore_upper=polyscore_upper, community='private' if private else None):
         output.historical_result(result)
 
 

--- a/src/polyswarm/client/live.py
+++ b/src/polyswarm/client/live.py
@@ -38,13 +38,14 @@ def live_stop(ctx, ruleset_id):
 @click.option('-f', '--family', help='Filter hunt results based on the family name.')
 @click.option('-l', '--polyscore-lower', help='Polyscore lower bound for the hunt results.')
 @click.option('-u', '--polyscore-upper', help='Polyscore upper bound for the hunt results.')
+@click.option('-p', '--private', is_flag=True, help='Filter results to only your private community.')
 @click.pass_context
-def live_results(ctx, since, rule_name, family, polyscore_lower, polyscore_upper):
+def live_results(ctx, since, rule_name, family, polyscore_lower, polyscore_upper, private):
     api = ctx.obj['api']
     output = ctx.obj['output']
     for result in api.live_feed(
             since, rule_name=rule_name, family=family,
-            polyscore_lower=polyscore_lower, polyscore_upper=polyscore_upper):
+            polyscore_lower=polyscore_lower, polyscore_upper=polyscore_upper, community='private' if private else None):
         output.live_result(result)
 
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -129,6 +129,13 @@ class HuntResultsTest(BaseTestCase):
             '--output-format', 'text', 'historical', 'results', '76083665328102613'])
         self._assert_text_result(result, self.click_vcr(result))
 
+
+    @vcr.use_cassette()
+    def test_historical_hunt_results_private_json(self):
+        result = self._run_cli([
+            '--output-format', 'json', 'historical', 'results', '76083665328102613', '--private'])
+        self._assert_json_result(result, self.click_vcr(result))
+
     @vcr.use_cassette()
     def test_live_feed_json(self):
         result = self._run_cli([
@@ -140,6 +147,13 @@ class HuntResultsTest(BaseTestCase):
         result = self._run_cli([
             '--output-format', 'text', 'live', 'feed', '--since', '9999999'])
         self._assert_text_result(result, self.click_vcr(result))
+
+    @vcr.use_cassette()
+    def test_live_feed_private_json(self):
+        result = self._run_cli([
+            '--output-format', 'json', 'live', 'feed', '--since', '9999999', '--private'])
+        print(result.stdout)
+        self._assert_json_result(result, self.click_vcr(result))
 
     @vcr.use_cassette()
     def test_live_result_json(self):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -152,7 +152,6 @@ class HuntResultsTest(BaseTestCase):
     def test_live_feed_private_json(self):
         result = self._run_cli([
             '--output-format', 'json', 'live', 'feed', '--since', '9999999', '--private'])
-        print(result.stdout)
         self._assert_json_result(result, self.click_vcr(result))
 
     @vcr.use_cassette()
@@ -276,13 +275,13 @@ class SubmissionTest(BaseTestCase):
     @vcr.use_cassette()
     def test_submission_lookup_json(self):
         result = self._run_cli([
-            '--output-format', 'json', 'lookup', '51433256212000920'])
+            '--output-format', 'json', 'lookup', '79185011799085464'])
         self._assert_json_result(result, self.click_vcr(result))
 
     @vcr.use_cassette()
     def test_submission_lookup_text(self):
         result = self._run_cli([
-            '--output-format', 'text', 'lookup', '51433256212000920'])
+            '--output-format', 'text', 'lookup', '79185011799085464'])
         self._assert_text_result(result, self.click_vcr(result))
 
     @vcr.use_cassette()
@@ -312,13 +311,13 @@ class SubmissionTest(BaseTestCase):
     @vcr.use_cassette()
     def test_submission_rescan_id_json(self):
         result = self._run_cli([
-            '--output-format', 'json', 'rescan-id', '78691987955427124'])
+            '--output-format', 'json', 'rescan-id', '79185011799085464'])
         self._assert_json_result(result, self.click_vcr(result))
 
     @vcr.use_cassette()
     def test_submission_rescan_id_text(self):
         result = self._run_cli([
-            '--output-format', 'text', 'rescan-id', '78691987955427124'])
+            '--output-format', 'text', 'rescan-id', '79185011799085464'])
         self._assert_text_result(result, self.click_vcr(result))
 
 

--- a/tests/vcr/test_download_cat.click
+++ b/tests/vcr/test_download_cat.click
@@ -1,1 +1,1 @@
-result: \x1f�\x08\x00\x03�\te\x02��0�W\x0cPup\x0c�6�\t��05�\x08��4wv�4�Uq�tv\x0c�\r\x0eq�sq\x0cr�u�\x0b�\x0c�\x0c\n\r�\rq\r\x0e�u��qUT����\x02\x00<�QhD\x00\x00\x00
+result: x1f�x08x00x03�tex02��0�Wx0cPupx0c�6�t��05�x08��4wv�4�Uq�tvx0c�rx0eq�sqx0cr�u�x0b�x0c�x0cnr�rqrx0e�u��qUT����x02x00<�QhDx00x00x00

--- a/tests/vcr/test_download_cat.click
+++ b/tests/vcr/test_download_cat.click
@@ -1,1 +1,1 @@
-result: x1f�x08x00x03�tex02��0�Wx0cPupx0c�6�t��05�x08��4wv�4�Uq�tvx0c�rx0eq�sqx0cr�u�x0b�x0c�x0cnr�rqrx0e�u��qUT����x02x00<�QhDx00x00x00
+result: X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*

--- a/tests/vcr/test_download_cat.click
+++ b/tests/vcr/test_download_cat.click
@@ -1,1 +1,1 @@
-result: X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
+result: \x1f�\x08\x00\x03�\te\x02��0�W\x0cPup\x0c�6�\t��05�\x08��4wv�4�Uq�tv\x0c�\r\x0eq�sq\x0cr�u�\x0b�\x0c�\x0c\n\r�\rq\r\x0e�u��qUT����\x02\x00<�QhD\x00\x00\x00

--- a/tests/vcr/test_download_cat.vcr
+++ b/tests/vcr/test_download_cat.vcr
@@ -59,16 +59,12 @@ interactions:
     uri: http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T202040Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=b1d54a1f5b2420d28e26a65415a23b0fd7c5657cd6158811a10282d421356be5
   response:
     body:
-      string: !!binary |
-        H4sIAAP9CWUC/4sw9VcMUHVwDIg2iQmIijA10QiI0zR3dtY0r1Vx9XR2DNINDnH0c3EMctF19Avx
-        DPMMCg3WDXENDtF18/RxVVTx0PbQAgA8z1FoRAAAAA==
+      string: X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
     headers:
       Accept-Ranges:
       - bytes
       Content-Disposition:
       - attachment;filename=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
-      Content-Encoding:
-      - gzip
       Content-Length:
       - '88'
       Content-Security-Policy:

--- a/tests/vcr/test_download_cat.vcr
+++ b/tests/vcr/test_download_cat.vcr
@@ -11,7 +11,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.4.2 (x86_64-Linux-CPython-3.10.7)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
     uri: http://artifact-index-e2e:9696/v3/consumer/download/sha256/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f?community=gamma
   response:
@@ -24,7 +24,7 @@ interactions:
 
         <h1>Redirecting...</h1>
 
-        <p>You should be redirected automatically to the target URL: <a href="http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&amp;response-content-type=application%2Foctet-stream&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230822%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20230822T214033Z&amp;X-Amz-Expires=3600&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=14b8e6568f9425577419c52bbb27b78c5a1590637850a7fb8428cfb678fa30ca">http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&amp;response-content-type=application%2Foctet-stream&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230822%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20230822T214033Z&amp;X-Amz-Expires=3600&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=14b8e6568f9425577419c52bbb27b78c5a1590637850a7fb8428cfb678fa30ca</a>.
+        <p>You should be redirected automatically to the target URL: <a href="http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&amp;response-content-type=application%2Foctet-stream&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20230919T182310Z&amp;X-Amz-Expires=3600&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=8860a738d048d2296459f82790a6ffc677977c104e1dbbec5547f7ff6a881b00">http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&amp;response-content-type=application%2Foctet-stream&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20230919T182310Z&amp;X-Amz-Expires=3600&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=8860a738d048d2296459f82790a6ffc677977c104e1dbbec5547f7ff6a881b00</a>.
         If not, click the link.
 
         '
@@ -36,9 +36,9 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Tue, 22 Aug 2023 21:40:33 GMT
+      - Tue, 19 Sep 2023 18:23:10 GMT
       Location:
-      - http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230822%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230822T214033Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=14b8e6568f9425577419c52bbb27b78c5a1590637850a7fb8428cfb678fa30ca
+      - http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182310Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=8860a738d048d2296459f82790a6ffc677977c104e1dbbec5547f7ff6a881b00
       Server:
       - gunicorn
     status:
@@ -54,12 +54,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.4.2 (x86_64-Linux-CPython-3.10.7)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230822%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230822T214033Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=14b8e6568f9425577419c52bbb27b78c5a1590637850a7fb8428cfb678fa30ca
+    uri: http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182310Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=8860a738d048d2296459f82790a6ffc677977c104e1dbbec5547f7ff6a881b00
   response:
     body:
-      string: X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
+      string: !!binary |
+        H4sIANLmCWUC/4sw9VcMUHVwDIg2iQmIijA10QiI0zR3dtY0r1Vx9XR2DNINDnH0c3EMctF19Avx
+        DPMMCg3WDXENDtF18/RxVVTx0PbQAgA8z1FoRAAAAA==
     headers:
       Accept-Ranges:
       - bytes
@@ -74,11 +76,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       Date:
-      - Tue, 22 Aug 2023 21:40:33 GMT
+      - Tue, 19 Sep 2023 18:23:10 GMT
       ETag:
-      - '"04bca5fda0e3e14939e102c511e8f038"'
+      - '"2af5706bff25a68abd02532800b3d685"'
       Last-Modified:
-      - Tue, 22 Aug 2023 21:34:08 GMT
+      - Tue, 19 Sep 2023 18:22:10 GMT
       Server:
       - MinIO
       Strict-Transport-Security:
@@ -86,13 +88,13 @@ interactions:
       Vary:
       - Origin
       X-Amz-Request-Id:
-      - 177DD274ABD63ABB
+      - 17865FEF1984F7F7
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       x-amz-expiration:
-      - expiry-date="Thu, 24 Aug 2023 00:00:00 GMT", rule-id="_public_1"
+      - expiry-date="Thu, 21 Sep 2023 00:00:00 GMT", rule-id="_public_1"
     status:
       code: 200
       message: OK

--- a/tests/vcr/test_download_cat.vcr
+++ b/tests/vcr/test_download_cat.vcr
@@ -24,7 +24,7 @@ interactions:
 
         <h1>Redirecting...</h1>
 
-        <p>You should be redirected automatically to the target URL: <a href="http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&amp;response-content-type=application%2Foctet-stream&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20230919T182310Z&amp;X-Amz-Expires=3600&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=8860a738d048d2296459f82790a6ffc677977c104e1dbbec5547f7ff6a881b00">http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&amp;response-content-type=application%2Foctet-stream&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20230919T182310Z&amp;X-Amz-Expires=3600&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=8860a738d048d2296459f82790a6ffc677977c104e1dbbec5547f7ff6a881b00</a>.
+        <p>You should be redirected automatically to the target URL: <a href="http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&amp;response-content-type=application%2Foctet-stream&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20230919T202040Z&amp;X-Amz-Expires=3600&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=b1d54a1f5b2420d28e26a65415a23b0fd7c5657cd6158811a10282d421356be5">http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&amp;response-content-type=application%2Foctet-stream&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20230919T202040Z&amp;X-Amz-Expires=3600&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=b1d54a1f5b2420d28e26a65415a23b0fd7c5657cd6158811a10282d421356be5</a>.
         If not, click the link.
 
         '
@@ -36,9 +36,9 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Tue, 19 Sep 2023 18:23:10 GMT
+      - Tue, 19 Sep 2023 20:20:40 GMT
       Location:
-      - http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182310Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=8860a738d048d2296459f82790a6ffc677977c104e1dbbec5547f7ff6a881b00
+      - http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T202040Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=b1d54a1f5b2420d28e26a65415a23b0fd7c5657cd6158811a10282d421356be5
       Server:
       - gunicorn
     status:
@@ -56,11 +56,11 @@ interactions:
       User-Agent:
       - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182310Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=8860a738d048d2296459f82790a6ffc677977c104e1dbbec5547f7ff6a881b00
+    uri: http://minio:9000/cache-public/27/5a/02/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f3395856ce81f2b7382dee72602f798b642f1414044d88612fea8a8f36de82e1278abb02f?response-content-disposition=attachment%3Bfilename%3D275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&response-content-type=application%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T202040Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=b1d54a1f5b2420d28e26a65415a23b0fd7c5657cd6158811a10282d421356be5
   response:
     body:
       string: !!binary |
-        H4sIANLmCWUC/4sw9VcMUHVwDIg2iQmIijA10QiI0zR3dtY0r1Vx9XR2DNINDnH0c3EMctF19Avx
+        H4sIAAP9CWUC/4sw9VcMUHVwDIg2iQmIijA10QiI0zR3dtY0r1Vx9XR2DNINDnH0c3EMctF19Avx
         DPMMCg3WDXENDtF18/RxVVTx0PbQAgA8z1FoRAAAAA==
     headers:
       Accept-Ranges:
@@ -76,11 +76,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       Date:
-      - Tue, 19 Sep 2023 18:23:10 GMT
+      - Tue, 19 Sep 2023 20:20:40 GMT
       ETag:
-      - '"2af5706bff25a68abd02532800b3d685"'
+      - '"e299c8adc88de587d6feec42edabe662"'
       Last-Modified:
-      - Tue, 19 Sep 2023 18:22:10 GMT
+      - Tue, 19 Sep 2023 19:56:51 GMT
       Server:
       - MinIO
       Strict-Transport-Security:
@@ -88,7 +88,7 @@ interactions:
       Vary:
       - Origin
       X-Amz-Request-Id:
-      - 17865FEF1984F7F7
+      - 178666589D7E0E1D
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/tests/vcr/test_historical_hunt_results_private_json.click
+++ b/tests/vcr/test_historical_hunt_results_private_json.click
@@ -1,0 +1,14 @@
+result: '{"created": "2023-08-23T15:13:07.968061", "detections": {"benign": 0, "malicious":
+  1, "total": 1}, "download_url": null, "historicalscan_id": "76083665328102613",
+  "id": "87292527615907450", "instance_id": "55295687268401015", "malware_family":
+  null, "polyscore": 0.23213458159978606, "rule_name": "eicar_substring_test", "sha256":
+  "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "tags": "{}",
+  "yara": null}
+
+  {"created": "2023-08-23T15:13:07.968061", "detections": {"benign": 0, "malicious":
+  1, "total": 1}, "download_url": null, "historicalscan_id": "76083665328102613",
+  "id": "624933739746082", "instance_id": "55295687268401015", "malware_family": null,
+  "polyscore": 0.23213458159978606, "rule_name": "eicar_av_test", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+  "tags": "{}", "yara": null}
+
+  '

--- a/tests/vcr/test_historical_hunt_results_private_json.vcr
+++ b/tests/vcr/test_historical_hunt_results_private_json.vcr
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.2 (x86_64-Linux-CPython-3.10.7)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/hunt/historical/results/list?id=76083665328102613&community=private
+  response:
+    body:
+      string: '{"has_more":false,"limit":2,"result":[{"created":"2023-08-23T15:13:07.968061","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"historicalscan_id":"76083665328102613","id":"87292527615907450","instance_id":"55295687268401015","malware_family":null,"polyscore":0.23213458159978606,"rule_name":"eicar_substring_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null},{"created":"2023-08-23T15:13:07.968061","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"historicalscan_id":"76083665328102613","id":"624933739746082","instance_id":"55295687268401015","malware_family":null,"polyscore":0.23213458159978606,"rule_name":"eicar_av_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null}],"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '843'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Aug 2023 15:14:20 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/test_live_feed_json.click
+++ b/tests/vcr/test_live_feed_json.click
@@ -1,20 +1,15 @@
-result: '{"created": "2022-05-26T19:41:33.797898", "detections": {"benign": 0, "malicious":
-  1, "total": 1}, "download_url": null, "id": "11704609705052856", "instance_id":
-  "99734963618630386", "livescan_id": "51856636346307547", "malware_family": null,
-  "polyscore": 0.23213458159978606, "rule_name": "eicar_substring_test", "sha256":
+result: '{"community": "gamma", "created": "2023-09-18T22:55:01.418046", "detections":
+  {"benign": 0, "malicious": 1, "total": 1}, "download_url": null, "id": "85163241984390761",
+  "instance_id": "56151690517356729", "livescan_id": "79107905790338419", "malware_family":
+  "EICAR", "polyscore": 0.23213458159978606, "rule_name": "eicar_substring_test",
+  "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "tags":
+  "{}", "yara": null}
+
+  {"community": "gamma", "created": "2023-09-18T22:55:01.411548", "detections": {"benign":
+  0, "malicious": 1, "total": 1}, "download_url": null, "id": "48317612869530221",
+  "instance_id": "56151690517356729", "livescan_id": "79107905790338419", "malware_family":
+  "EICAR", "polyscore": 0.23213458159978606, "rule_name": "eicar_av_test", "sha256":
   "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "tags": "{}",
   "yara": null}
-
-  {"created": "2022-05-26T19:41:33.790079", "detections": {"benign": 0, "malicious":
-  1, "total": 1}, "download_url": null, "id": "44381608066020879", "instance_id":
-  "99734963618630386", "livescan_id": "51856636346307547", "malware_family": null,
-  "polyscore": 0.23213458159978606, "rule_name": "eicar_av_test", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
-  "tags": "{}", "yara": null}
-
-  {"created": "2022-05-26T18:49:08.750640", "detections": {"benign": 0, "malicious":
-  1, "total": 1}, "download_url": null, "id": "30070311633556152", "instance_id":
-  "80845414726025917", "livescan_id": "57028981462665681", "malware_family": null,
-  "polyscore": 0.23213458159978606, "rule_name": "eicar_av_test", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
-  "tags": "{}", "yara": null}
 
   '

--- a/tests/vcr/test_live_feed_json.vcr
+++ b/tests/vcr/test_live_feed_json.vcr
@@ -11,57 +11,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.2 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/hunt/live/list?since=9999999
+    uri: http://artifact-index-e2e:9696/v3/hunt/live/list?since=9999999&community=gamma
   response:
     body:
-      string: '{"has_more":true,"limit":2,"offset":"gAAAAABij9iR_8nX4jhGhmmJ0_Ki4OB5lJI5nowe0FZ9GBpnjQWl58jn4zKGcIw_pom779E7YbuP8lUQypRf21AH6BnKzOstfnGGif8BjBOLoejFUR2_kTxo5pW734sxBoO4r3Ibi71j","result":[{"created":"2022-05-26T19:41:33.797898","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"11704609705052856","instance_id":"99734963618630386","livescan_id":"51856636346307547","malware_family":null,"polyscore":0.23213458159978606,"rule_name":"eicar_substring_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null},{"created":"2022-05-26T19:41:33.790079","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"44381608066020879","instance_id":"99734963618630386","livescan_id":"51856636346307547","malware_family":null,"polyscore":0.23213458159978606,"rule_name":"eicar_av_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null}],"status":"OK"}
+      string: '{"has_more":false,"limit":50,"result":[{"community":"gamma","created":"2023-09-18T22:55:01.418046","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"85163241984390761","instance_id":"56151690517356729","livescan_id":"79107905790338419","malware_family":"EICAR","polyscore":0.23213458159978606,"rule_name":"eicar_substring_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null},{"community":"gamma","created":"2023-09-18T22:55:01.411548","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"48317612869530221","instance_id":"56151690517356729","livescan_id":"79107905790338419","malware_family":"EICAR","polyscore":0.23213458159978606,"rule_name":"eicar_av_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null}],"status":"OK"}
 
         '
     headers:
-      Content-Length:
-      - '984'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 26 May 2022 19:44:17 GMT
-      Server:
-      - Werkzeug/1.0.1 Python/3.9.6
-      X-Billing-ID:
-      - '1'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - '11111111111111111111111111111111'
       Connection:
       - keep-alive
-      User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
-    method: GET
-    uri: http://artifact-index-e2e:9696/v3/hunt/live/list?since=9999999&offset=gAAAAABij9iR_8nX4jhGhmmJ0_Ki4OB5lJI5nowe0FZ9GBpnjQWl58jn4zKGcIw_pom779E7YbuP8lUQypRf21AH6BnKzOstfnGGif8BjBOLoejFUR2_kTxo5pW734sxBoO4r3Ibi71j&limit=2
-  response:
-    body:
-      string: '{"has_more":false,"limit":2,"result":[{"created":"2022-05-26T18:49:08.750640","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"30070311633556152","instance_id":"80845414726025917","livescan_id":"57028981462665681","malware_family":null,"polyscore":0.23213458159978606,"rule_name":"eicar_av_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null}],"status":"OK"}
-
-        '
-    headers:
       Content-Length:
-      - '440'
+      - '880'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:44:17 GMT
+      - Mon, 18 Sep 2023 23:16:19 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_live_feed_private_json.click
+++ b/tests/vcr/test_live_feed_private_json.click
@@ -1,26 +1,29 @@
-result: 'error [polyswarm.client.polyswarm]: Error when running the request:
+result: '{"community": "delta", "created": "2023-09-19T17:34:17.102182", "detections":
+  {"benign": 0, "malicious": 12, "total": 12}, "download_url": null, "id": "48037939619001750",
+  "instance_id": "43196236583743555", "livescan_id": "29581829337559529", "malware_family":
+  "Emotet", "polyscore": 0.9999999475777902, "rule_name": "eicar_substring_test",
+  "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "tags":
+  "{}", "yara": null}
 
-  error [polyswarm.client.polyswarm]: {
+  {"community": "delta", "created": "2023-09-19T17:34:17.091140", "detections": {"benign":
+  0, "malicious": 12, "total": 12}, "download_url": null, "id": "67902367700958941",
+  "instance_id": "43196236583743555", "livescan_id": "29581829337559529", "malware_family":
+  "Emotet", "polyscore": 0.9999999475777902, "rule_name": "eicar_av_test", "sha256":
+  "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "tags": "{}",
+  "yara": null}
 
-  error [polyswarm.client.polyswarm]:     "method": "GET",
+  {"community": "delta", "created": "2023-09-19T17:34:17.076344", "detections": {"benign":
+  0, "malicious": 12, "total": 12}, "download_url": null, "id": "34388290477361236",
+  "instance_id": "43196236583743555", "livescan_id": "53070128370462357", "malware_family":
+  "Emotet", "polyscore": 0.9999999475777902, "rule_name": "eicar_substring_test",
+  "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "tags":
+  "{}", "yara": null}
 
-  error [polyswarm.client.polyswarm]:     "params": {
-
-  error [polyswarm.client.polyswarm]:         "community": "private",
-
-  error [polyswarm.client.polyswarm]:         "since": 9999999
-
-  error [polyswarm.client.polyswarm]:     },
-
-  error [polyswarm.client.polyswarm]:     "timeout": 30,
-
-  error [polyswarm.client.polyswarm]:     "url": "http://artifact-index-e2e:9696/v3/hunt/live/list"
-
-  error [polyswarm.client.polyswarm]: }
-
-  error [polyswarm.client.polyswarm]: Return code: 401
-
-  error [polyswarm.client.polyswarm]: Message: Account does not have access to any
-  private communities
+  {"community": "delta", "created": "2023-09-19T17:34:17.060035", "detections": {"benign":
+  0, "malicious": 12, "total": 12}, "download_url": null, "id": "86452401095184032",
+  "instance_id": "43196236583743555", "livescan_id": "53070128370462357", "malware_family":
+  "Emotet", "polyscore": 0.9999999475777902, "rule_name": "eicar_av_test", "sha256":
+  "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "tags": "{}",
+  "yara": null}
 
   '

--- a/tests/vcr/test_live_feed_private_json.click
+++ b/tests/vcr/test_live_feed_private_json.click
@@ -1,0 +1,26 @@
+result: 'error [polyswarm.client.polyswarm]: Error when running the request:
+
+  error [polyswarm.client.polyswarm]: {
+
+  error [polyswarm.client.polyswarm]:     "method": "GET",
+
+  error [polyswarm.client.polyswarm]:     "params": {
+
+  error [polyswarm.client.polyswarm]:         "community": "private",
+
+  error [polyswarm.client.polyswarm]:         "since": 9999999
+
+  error [polyswarm.client.polyswarm]:     },
+
+  error [polyswarm.client.polyswarm]:     "timeout": 30,
+
+  error [polyswarm.client.polyswarm]:     "url": "http://artifact-index-e2e:9696/v3/hunt/live/list"
+
+  error [polyswarm.client.polyswarm]: }
+
+  error [polyswarm.client.polyswarm]: Return code: 401
+
+  error [polyswarm.client.polyswarm]: Message: Account does not have access to any
+  private communities
+
+  '

--- a/tests/vcr/test_live_feed_private_json.vcr
+++ b/tests/vcr/test_live_feed_private_json.vcr
@@ -7,31 +7,32 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - '11111111111111111111111111111111'
+      - 11111111111111111111111111111111
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.4.2 (x86_64-Linux-CPython-3.9.10)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
     uri: http://artifact-index-e2e:9696/v3/hunt/live/list?since=9999999&community=private
   response:
     body:
-      string: '{"errors":null,"result":"Account does not have access to any private
-        communities","status":"error"}
+      string: '{"has_more":false,"limit":50,"result":[{"community":"delta","created":"2023-09-19T17:34:17.102182","detections":{"benign":0,"malicious":12,"total":12},"download_url":null,"id":"48037939619001750","instance_id":"43196236583743555","livescan_id":"29581829337559529","malware_family":"Emotet","polyscore":0.9999999475777902,"rule_name":"eicar_substring_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null},{"community":"delta","created":"2023-09-19T17:34:17.091140","detections":{"benign":0,"malicious":12,"total":12},"download_url":null,"id":"67902367700958941","instance_id":"43196236583743555","livescan_id":"29581829337559529","malware_family":"Emotet","polyscore":0.9999999475777902,"rule_name":"eicar_av_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null},{"community":"delta","created":"2023-09-19T17:34:17.076344","detections":{"benign":0,"malicious":12,"total":12},"download_url":null,"id":"34388290477361236","instance_id":"43196236583743555","livescan_id":"53070128370462357","malware_family":"Emotet","polyscore":0.9999999475777902,"rule_name":"eicar_substring_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null},{"community":"delta","created":"2023-09-19T17:34:17.060035","detections":{"benign":0,"malicious":12,"total":12},"download_url":null,"id":"86452401095184032","instance_id":"43196236583743555","livescan_id":"53070128370462357","malware_family":"Emotet","polyscore":0.9999999475777902,"rule_name":"eicar_av_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null}],"status":"OK"}
 
         '
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '100'
+      - '1713'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Sep 2023 23:22:15 GMT
-      Server:
-      - gunicorn
+      - Tue, 19 Sep 2023 17:44:34 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Billing-ID:
+      - '68015377376034'
     status:
-      code: 401
-      message: UNAUTHORIZED
+      code: 200
+      message: OK
 version: 1

--- a/tests/vcr/test_live_feed_private_json.vcr
+++ b/tests/vcr/test_live_feed_private_json.vcr
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.2 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/hunt/live/list?since=9999999&community=private
+  response:
+    body:
+      string: '{"errors":null,"result":"Account does not have access to any private
+        communities","status":"error"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Sep 2023 23:22:15 GMT
+      Server:
+      - gunicorn
+    status:
+      code: 401
+      message: UNAUTHORIZED
+version: 1

--- a/tests/vcr/test_live_feed_text.click
+++ b/tests/vcr/test_live_feed_text.click
@@ -1,29 +1,14 @@
-result: 'Id: 11704609705052856
+result: 'Id: 85163241984390761
 
-  Instance Id: 99734963618630386
+  Instance Id: 56151690517356729
 
-  Created at: 2022-05-26 19:41:33.797898
+  Created at: 2023-09-18 22:55:01.418046
 
   SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
 
   Rule: eicar_substring_test
 
-  PolyScore: 0.23213458159978606066
-
-  Detections: 1/1 engines reported malicious
-
-  Tags: {}
-
-
-  Id: 44381608066020879
-
-  Instance Id: 99734963618630386
-
-  Created at: 2022-05-26 19:41:33.790079
-
-  SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
-
-  Rule: eicar_av_test
+  Malware Family: EICAR
 
   PolyScore: 0.23213458159978606066
 
@@ -32,15 +17,17 @@ result: 'Id: 11704609705052856
   Tags: {}
 
 
-  Id: 30070311633556152
+  Id: 48317612869530221
 
-  Instance Id: 80845414726025917
+  Instance Id: 56151690517356729
 
-  Created at: 2022-05-26 18:49:08.750640
+  Created at: 2023-09-18 22:55:01.411548
 
   SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
 
   Rule: eicar_av_test
+
+  Malware Family: EICAR
 
   PolyScore: 0.23213458159978606066
 

--- a/tests/vcr/test_live_feed_text.vcr
+++ b/tests/vcr/test_live_feed_text.vcr
@@ -11,57 +11,25 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.2 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/hunt/live/list?since=9999999
+    uri: http://artifact-index-e2e:9696/v3/hunt/live/list?since=9999999&community=gamma
   response:
     body:
-      string: '{"has_more":true,"limit":2,"offset":"gAAAAABij9iRh-cqK3BEDq6rtHctPW3ze7j9P2kTwl5XgbDVl1zM_Yd8ChRbtI8U_RNy5DLpzEL1F0waQcAh7tyBn5asMSkwr0C3xPHNFKtLwe0MzKx5v0d9B9Iks_GG1v5lWks21c4J","result":[{"created":"2022-05-26T19:41:33.797898","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"11704609705052856","instance_id":"99734963618630386","livescan_id":"51856636346307547","malware_family":null,"polyscore":0.23213458159978606,"rule_name":"eicar_substring_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null},{"created":"2022-05-26T19:41:33.790079","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"44381608066020879","instance_id":"99734963618630386","livescan_id":"51856636346307547","malware_family":null,"polyscore":0.23213458159978606,"rule_name":"eicar_av_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null}],"status":"OK"}
+      string: '{"has_more":false,"limit":50,"result":[{"community":"gamma","created":"2023-09-18T22:55:01.418046","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"85163241984390761","instance_id":"56151690517356729","livescan_id":"79107905790338419","malware_family":"EICAR","polyscore":0.23213458159978606,"rule_name":"eicar_substring_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null},{"community":"gamma","created":"2023-09-18T22:55:01.411548","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"48317612869530221","instance_id":"56151690517356729","livescan_id":"79107905790338419","malware_family":"EICAR","polyscore":0.23213458159978606,"rule_name":"eicar_av_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null}],"status":"OK"}
 
         '
     headers:
-      Content-Length:
-      - '984'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 26 May 2022 19:44:17 GMT
-      Server:
-      - Werkzeug/1.0.1 Python/3.9.6
-      X-Billing-ID:
-      - '1'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - '11111111111111111111111111111111'
       Connection:
       - keep-alive
-      User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
-    method: GET
-    uri: http://artifact-index-e2e:9696/v3/hunt/live/list?since=9999999&offset=gAAAAABij9iRh-cqK3BEDq6rtHctPW3ze7j9P2kTwl5XgbDVl1zM_Yd8ChRbtI8U_RNy5DLpzEL1F0waQcAh7tyBn5asMSkwr0C3xPHNFKtLwe0MzKx5v0d9B9Iks_GG1v5lWks21c4J&limit=2
-  response:
-    body:
-      string: '{"has_more":false,"limit":2,"result":[{"created":"2022-05-26T18:49:08.750640","detections":{"benign":0,"malicious":1,"total":1},"download_url":null,"id":"30070311633556152","instance_id":"80845414726025917","livescan_id":"57028981462665681","malware_family":null,"polyscore":0.23213458159978606,"rule_name":"eicar_av_test","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","tags":"{}","yara":null}],"status":"OK"}
-
-        '
-    headers:
       Content-Length:
-      - '440'
+      - '880'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:44:17 GMT
+      - Mon, 18 Sep 2023 23:16:19 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_search_hash_with_text_output.click
+++ b/tests/vcr/test_search_hash_with_text_output.click
@@ -1,11 +1,11 @@
 result: "============================= Artifact Instance =============================\n\
-  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\n\
+  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/34662403920188484\n\
   Detections: 1/1 engines reported malicious\n\tengine-eicar: Malicious, metadata:\
-  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 55586109639806877\n\
+  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 34662403920188484\n\
   SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\nSHA1:\
   \ 3395856ce81f2b7382dee72602f798b642f14140\nMD5: 44d88612fea8a8f36de82e1278abb02f\n\
   File type: mimetype: text/plain, extended_info: EICAR virus test files\nSSDEEP:\
   \ 3:a+JraNvsgzsVqSwHq9:tJuOgzsko\nTLSH: 41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228\n\
-  First seen: 2022-05-26 16:25:31 UTC\nLast scanned: 2022-05-26 19:10:08 UTC\n\
-  Last seen: 2022-05-26 19:10:08 UTC\nStatus: Assertion window closed\nFilename:\
-  \ malicious\nCommunity: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"
+  First seen: 2023-09-19 19:47:15 UTC\nLast scanned: 2023-09-19 19:56:50 UTC\nLast\
+  \ seen: 2023-09-19 19:56:50 UTC\nStatus: Assertion window closed\nFilename: malicious\n\
+  Community: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"

--- a/tests/vcr/test_search_hash_with_text_output.vcr
+++ b/tests/vcr/test_search_hash_with_text_output.vcr
@@ -11,24 +11,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
     uri: http://artifact-index-e2e:9696/v3/search/hash/sha256?hash=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f&community=gamma
   response:
     body:
-      string: '{"has_more":false,"limit":2,"result":[{"artifact_id":"55586109639806877","assertions":[{"author":"93822790783196","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2022-05-26T19:10:08.398135","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"55586109639806877","last_scanned":"2022-05-26T19:10:08.398135","last_seen":"2022-05-26T19:10:08.398135","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:10:38.613625"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:10:08.852154"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:10:10.835393"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"707133430915539","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true}],"status":"OK"}
+      string: '{"has_more":false,"limit":50,"result":[{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":"2023-09-19T19:56:50.907719","last_seen":"2023-09-19T19:56:50.907719","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:57:21.134339","tool":"polyunite","tool_metadata":{"labels":["nonmalware"],"malware_family":"EICAR","operating_system":[]},"updated":"2023-09-19T19:57:21.134339"},{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[{"arbiter":"490109106931282","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true}],"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2568'
+      - '3046'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:10:39 GMT
+      - Tue, 19 Sep 2023 19:58:26 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_submission_create_json.click
+++ b/tests/vcr/test_submission_create_json.click
@@ -1,31 +1,30 @@
-result: '{"artifact_id": "20225644836824972", "assertions": [{"author": "93822790783196",
+result: '{"artifact_id": "34662403920188484", "assertions": [{"author": "321669517060332",
   "author_name": "engine-eicar", "bid": "1000000000000000000", "engine": {"description":
   "Webhook-Engine", "name": "engine-eicar"}, "mask": true, "metadata": {"malware_family":
   "EICAR", "product": "eicar"}, "verdict": true}], "community": "gamma", "country":
-  "", "created": "2022-05-26T19:08:32.215371", "detections": {"benign": 0, "malicious":
+  "", "created": "2023-09-19T19:56:50.907719", "detections": {"benign": 0, "malicious":
   1, "total": 1}, "extended_type": "EICAR virus test files", "failed": false, "filename":
-  "malicious", "first_seen": "2022-05-26T16:25:31.875900", "id": "20225644836824972",
-  "last_scanned": "2022-05-26T19:08:32.215371", "last_seen": "2022-05-26T19:08:32.215371",
-  "md5": "44d88612fea8a8f36de82e1278abb02f", "metadata": [{"created": "2022-05-26T17:38:57.900531",
-  "tool": "test_tool_2", "tool_metadata": {"key2": "value2"}, "updated": "2022-05-26T17:38:57.900531"},
-  {"created": "2022-05-26T17:38:57.831542", "tool": "test_tool_1", "tool_metadata":
-  {"key": "value"}, "updated": "2022-05-26T17:38:57.831542"}, {"created": "2022-05-26T16:26:02.695665",
-  "tool": "polyunite", "tool_metadata": {"labels": [], "malware_family": null, "operating_system":
-  []}, "updated": "2022-05-26T19:09:02.607193"}, {"created": "2022-05-26T16:25:35.181822",
-  "tool": "strings", "tool_metadata": {"domains": [], "ipv4": [], "ipv6": [], "urls":
-  []}, "updated": "2022-05-26T19:08:32.521659"}, {"created": "2022-05-26T16:25:33.326291",
-  "tool": "hash", "tool_metadata": {"md5": "44d88612fea8a8f36de82e1278abb02f", "sha1":
-  "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+  "malicious", "first_seen": "2023-09-19T19:47:15.833914", "id": "34662403920188484",
+  "last_scanned": "2023-09-19T19:56:50.907719", "last_seen": "2023-09-19T19:56:50.907719",
+  "md5": "44d88612fea8a8f36de82e1278abb02f", "metadata": [{"created": "2023-09-19T19:57:21.134339",
+  "tool": "polyunite", "tool_metadata": {"labels": ["nonmalware"], "malware_family":
+  "EICAR", "operating_system": []}, "updated": "2023-09-19T19:57:21.134339"}, {"created":
+  "2023-09-19T19:56:51.170727", "tool": "hash", "tool_metadata": {"md5": "44d88612fea8a8f36de82e1278abb02f",
+  "sha1": "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
   "sha3_256": "8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8",
   "sha3_512": "a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007",
   "sha512": "cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab",
   "ssdeep": "3:a+JraNvsgzsVqSwHq9:tJuOgzsko", "tlsh": "41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},
-  "updated": "2022-05-26T19:08:32.540826"}], "mimetype": "text/plain", "polyscore":
-  0.23213458159978606, "result": null, "sha1": "3395856ce81f2b7382dee72602f798b642f14140",
-  "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "size":
-  68, "type": "FILE", "upload_url": "http://minio:9000/instances/ad/ff/c6/adffc602-8e9d-41ac-af99-70b2df06c288?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20220526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220526T190832Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=1489373eef068dd21dd430a656757abe2c2243e87008d7097fcc7f6cd3e7387a",
-  "votes": [{"arbiter": "707133430915539", "arbiter_name": "arbiter-eicar", "engine":
-  {"description": "Webhook-Arbiter", "name": "arbiter-eicar"}, "metadata": {"malware_family":
-  "EICAR", "product": "eicar"}, "vote": true}], "window_closed": true}
+  "updated": "2023-09-19T19:56:51.251018"}, {"created": "2023-09-19T19:56:51.170727",
+  "tool": "exiftool", "tool_metadata": {"directory": "/tmp", "exiftoolversion": 12.25,
+  "fileaccessdate": "2023:09:19 19:56:51+00:00", "fileinodechangedate": "2023:09:19
+  19:56:51+00:00", "filemodifydate": "2023:09:19 19:56:51+00:00", "filename": "tmpceb072j0",
+  "filepermissions": "-rw-r--r--", "filesize": "68 bytes", "filetype": "TXT", "filetypeextension":
+  "txt", "linecount": 1, "mimeencoding": "us-ascii", "mimetype": "text/plain", "newlines":
+  "(none)", "sourcefile": "/tmp/tmpceb072j0", "wordcount": 1}, "updated": "2023-09-19T19:56:51.359539"}],
+  "mimetype": "text/plain", "polyscore": 0.23213458159978606, "result": null, "sha1":
+  "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+  "size": 68, "type": "FILE", "upload_url": "http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94",
+  "votes": [], "window_closed": true}
 
   '

--- a/tests/vcr/test_submission_create_json.vcr
+++ b/tests/vcr/test_submission_create_json.vcr
@@ -15,23 +15,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: POST
     uri: http://artifact-index-e2e:9696/v3/instance
   response:
     body:
-      string: '{"result":{"artifact_id":"20225644836824972","assertions":[],"community":"gamma","country":"","created":"2022-05-26T19:08:32.215371","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2022-05-26T19:08:32.215371","id":"20225644836824972","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/ad/ff/c6/adffc602-8e9d-41ac-af99-70b2df06c288?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20220526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220526T190832Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=1489373eef068dd21dd430a656757abe2c2243e87008d7097fcc7f6cd3e7387a","votes":[],"window_closed":false},"status":"OK"}
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2023-09-19T19:56:50.907719","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
       - '842'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:08:32 GMT
+      - Tue, 19 Sep 2023 19:56:50 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:
@@ -55,9 +57,9 @@ interactions:
       Content-Length:
       - '68'
       User-Agent:
-      - python-requests/2.22.0
+      - python-requests/2.27.1
     method: PUT
-    uri: http://minio:9000/instances/ad/ff/c6/adffc602-8e9d-41ac-af99-70b2df06c288?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20220526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220526T190832Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=1489373eef068dd21dd430a656757abe2c2243e87008d7097fcc7f6cd3e7387a
+    uri: http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94
   response:
     body:
       string: ''
@@ -69,7 +71,7 @@ interactions:
       Content-Security-Policy:
       - block-all-mixed-content
       Date:
-      - Thu, 26 May 2022 19:08:32 GMT
+      - Tue, 19 Sep 2023 19:56:50 GMT
       ETag:
       - '"44d88612fea8a8f36de82e1278abb02f"'
       Server:
@@ -80,13 +82,13 @@ interactions:
       - Origin
       - Accept-Encoding
       X-Amz-Request-Id:
-      - 16F2BD43D68964C4
+      - 1786650BC2747DA0
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       x-amz-expiration:
-      - expiry-date="Sat, 28 May 2022 00:00:00 GMT", rule-id="instances_0"
+      - expiry-date="Thu, 21 Sep 2023 00:00:00 GMT", rule-id="instances_0"
     status:
       code: 200
       message: OK
@@ -104,23 +106,25 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: PUT
-    uri: http://artifact-index-e2e:9696/v3/instance?id=20225644836824972
+    uri: http://artifact-index-e2e:9696/v3/instance?id=34662403920188484
   response:
     body:
-      string: '{"result":{"artifact_id":"20225644836824972","assertions":[],"community":"gamma","country":"","created":"2022-05-26T19:08:32.215371","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2022-05-26T19:08:32.215371","id":"20225644836824972","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/ad/ff/c6/adffc602-8e9d-41ac-af99-70b2df06c288?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20220526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220526T190832Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=1489373eef068dd21dd430a656757abe2c2243e87008d7097fcc7f6cd3e7387a","votes":[],"window_closed":false},"status":"OK"}
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2023-09-19T19:56:50.907719","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
       - '842'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:08:32 GMT
+      - Tue, 19 Sep 2023 19:56:50 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:
@@ -138,24 +142,1185 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/20225644836824972
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
   response:
     body:
-      string: '{"result":{"artifact_id":"20225644836824972","assertions":[{"author":"93822790783196","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2022-05-26T19:08:32.215371","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"20225644836824972","last_scanned":"2022-05-26T19:08:32.215371","last_seen":"2022-05-26T19:08:32.215371","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:09:02.607193"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:08:32.521659"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:08:32.540826"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/ad/ff/c6/adffc602-8e9d-41ac-af99-70b2df06c288?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20220526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220526T190832Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=1489373eef068dd21dd430a656757abe2c2243e87008d7097fcc7f6cd3e7387a","votes":[{"arbiter":"707133430915539","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2023-09-19T19:56:50.907719","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2876'
+      - '842'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:09:03 GMT
+      - Tue, 19 Sep 2023 19:56:51 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:56:52 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:56:53 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:56:54 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:56:55 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:56:56 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:56:57 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:56:58 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:56:59 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:00 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:01 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:02 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:03 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:04 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:05 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:06 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:08 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:09 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:10 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:11 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:12 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:13 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:14 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:15 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:16 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:17 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:18 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:19 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:20 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/34662403920188484
+  response:
+    body:
+      string: '{"result":{"artifact_id":"34662403920188484","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:56:50.907719","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"34662403920188484","last_scanned":"2023-09-19T19:56:50.907719","last_seen":"2023-09-19T19:56:50.907719","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:57:21.134339","tool":"polyunite","tool_metadata":{"labels":["nonmalware"],"malware_family":"EICAR","operating_system":[]},"updated":"2023-09-19T19:57:21.134339"},{"created":"2023-09-19T19:56:51.170727","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:56:51.251018"},{"created":"2023-09-19T19:56:51.170727","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:56:51+00:00","fileinodechangedate":"2023:09:19 19:56:51+00:00","filemodifydate":"2023:09:19
+        19:56:51+00:00","filename":"tmpceb072j0","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpceb072j0","wordcount":1},"updated":"2023-09-19T19:56:51.359539"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/ef/8a/beef8a95-4d0d-4ebc-a5db-396c43c9a9b7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T195650Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c71d05a50550f9504ed33b9a3eece0c12c52ae4b012a59813118cf009c177d94","votes":[],"window_closed":true},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2822'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:57:21 GMT
+      Server:
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_submission_create_text.click
+++ b/tests/vcr/test_submission_create_text.click
@@ -1,11 +1,11 @@
 result: "============================= Artifact Instance =============================\n\
-  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\n\
+  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/43636978361271647\n\
   Detections: 1/1 engines reported malicious\n\tengine-eicar: Malicious, metadata:\
-  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 20225644836824972\n\
+  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 43636978361271647\n\
   SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\nSHA1:\
   \ 3395856ce81f2b7382dee72602f798b642f14140\nMD5: 44d88612fea8a8f36de82e1278abb02f\n\
   File type: mimetype: text/plain, extended_info: EICAR virus test files\nSSDEEP:\
   \ 3:a+JraNvsgzsVqSwHq9:tJuOgzsko\nTLSH: 41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228\n\
-  First seen: 2022-05-26 16:25:31 UTC\nLast scanned: 2022-05-26 19:08:32 UTC\n\
-  Last seen: 2022-05-26 19:08:32 UTC\nStatus: Assertion window closed\nFilename:\
-  \ malicious\nCommunity: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"
+  First seen: 2023-09-19 18:22:09 UTC\nLast scanned: 2023-09-19 18:25:50 UTC\nLast\
+  \ seen: 2023-09-19 18:25:50 UTC\nStatus: Assertion window closed\nFilename: malicious\n\
+  Community: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"

--- a/tests/vcr/test_submission_create_text.vcr
+++ b/tests/vcr/test_submission_create_text.vcr
@@ -15,23 +15,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: POST
     uri: http://artifact-index-e2e:9696/v3/instance
   response:
     body:
-      string: '{"result":{"artifact_id":"20225644836824972","assertions":[],"community":"gamma","country":"","created":"2022-05-26T19:08:32.215371","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2022-05-26T19:08:32.215371","id":"20225644836824972","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/ad/ff/c6/adffc602-8e9d-41ac-af99-70b2df06c288?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20220526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220526T190832Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=1489373eef068dd21dd430a656757abe2c2243e87008d7097fcc7f6cd3e7387a","votes":[],"window_closed":false},"status":"OK"}
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2023-09-19T18:25:50.604201","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
       - '842'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:08:32 GMT
+      - Tue, 19 Sep 2023 18:25:50 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:
@@ -55,9 +57,9 @@ interactions:
       Content-Length:
       - '68'
       User-Agent:
-      - python-requests/2.22.0
+      - python-requests/2.27.1
     method: PUT
-    uri: http://minio:9000/instances/ad/ff/c6/adffc602-8e9d-41ac-af99-70b2df06c288?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20220526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220526T190832Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=1489373eef068dd21dd430a656757abe2c2243e87008d7097fcc7f6cd3e7387a
+    uri: http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b
   response:
     body:
       string: ''
@@ -69,7 +71,7 @@ interactions:
       Content-Security-Policy:
       - block-all-mixed-content
       Date:
-      - Thu, 26 May 2022 19:08:32 GMT
+      - Tue, 19 Sep 2023 18:25:50 GMT
       ETag:
       - '"44d88612fea8a8f36de82e1278abb02f"'
       Server:
@@ -80,13 +82,13 @@ interactions:
       - Origin
       - Accept-Encoding
       X-Amz-Request-Id:
-      - 16F2BD43D68964C4
+      - 178660146EAF8C4B
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
       x-amz-expiration:
-      - expiry-date="Sat, 28 May 2022 00:00:00 GMT", rule-id="instances_0"
+      - expiry-date="Thu, 21 Sep 2023 00:00:00 GMT", rule-id="instances_0"
     status:
       code: 200
       message: OK
@@ -104,23 +106,25 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: PUT
-    uri: http://artifact-index-e2e:9696/v3/instance?id=20225644836824972
+    uri: http://artifact-index-e2e:9696/v3/instance?id=43636978361271647
   response:
     body:
-      string: '{"result":{"artifact_id":"20225644836824972","assertions":[],"community":"gamma","country":"","created":"2022-05-26T19:08:32.215371","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2022-05-26T19:08:32.215371","id":"20225644836824972","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/ad/ff/c6/adffc602-8e9d-41ac-af99-70b2df06c288?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20220526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220526T190832Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=1489373eef068dd21dd430a656757abe2c2243e87008d7097fcc7f6cd3e7387a","votes":[],"window_closed":false},"status":"OK"}
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2023-09-19T18:25:50.604201","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
       - '842'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:08:32 GMT
+      - Tue, 19 Sep 2023 18:25:50 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:
@@ -138,24 +142,1185 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/20225644836824972
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
   response:
     body:
-      string: '{"result":{"artifact_id":"20225644836824972","assertions":[{"author":"93822790783196","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2022-05-26T19:08:32.215371","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"20225644836824972","last_scanned":"2022-05-26T19:08:32.215371","last_seen":"2022-05-26T19:08:32.215371","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:09:02.607193"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:08:32.521659"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:08:32.540826"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/ad/ff/c6/adffc602-8e9d-41ac-af99-70b2df06c288?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20220526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220526T190832Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=1489373eef068dd21dd430a656757abe2c2243e87008d7097fcc7f6cd3e7387a","votes":[{"arbiter":"707133430915539","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":null,"failed":false,"filename":"malicious","first_seen":"2023-09-19T18:25:50.604201","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":null,"metadata":[],"mimetype":null,"polyscore":null,"result":null,"sha1":null,"sha256":null,"size":null,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2876'
+      - '842'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:09:03 GMT
+      - Tue, 19 Sep 2023 18:25:50 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:25:51 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:25:52 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:25:53 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:25:54 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:25:56 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:25:57 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:25:58 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:25:59 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:00 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:01 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:02 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:03 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:04 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:05 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:06 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:07 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:08 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:10 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:11 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:12 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:13 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:14 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:15 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:16 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:17 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:18 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:19 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2540'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:20 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/43636978361271647
+  response:
+    body:
+      string: '{"result":{"artifact_id":"43636978361271647","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:25:50.604201","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"43636978361271647","last_scanned":"2023-09-19T18:25:50.604201","last_seen":"2023-09-19T18:25:50.604201","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:21.468051","tool":"polyunite","tool_metadata":{"labels":["nonmalware"],"malware_family":"EICAR","operating_system":[]},"updated":"2023-09-19T18:26:21.468051"},{"created":"2023-09-19T18:25:50.745149","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:25:50.781529"},{"created":"2023-09-19T18:25:50.745149","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:25:50+00:00","fileinodechangedate":"2023:09:19 18:25:50+00:00","filemodifydate":"2023:09:19
+        18:25:50+00:00","filename":"tmp7im9e71b","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp7im9e71b","wordcount":1},"updated":"2023-09-19T18:25:50.886867"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/be/16/52/be1652e7-88a6-4d74-b88f-53bc1457759d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T182550Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=c3d6f79b7093b05247008a9628266fc3dbc41d85c8239ca7e84b4464e7bc756b","votes":[],"window_closed":true},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2822'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:21 GMT
+      Server:
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_submission_lookup_json.click
+++ b/tests/vcr/test_submission_lookup_json.click
@@ -1,31 +1,32 @@
-result: '{"artifact_id": "51433256212000920", "assertions": [{"author": "93822790783196",
+result: '{"artifact_id": "79185011799085464", "assertions": [{"author": "321669517060332",
   "author_name": "engine-eicar", "bid": "1000000000000000000", "engine": {"description":
   "Webhook-Engine", "name": "engine-eicar"}, "mask": true, "metadata": {"malware_family":
   "EICAR", "product": "eicar"}, "verdict": true}], "community": "gamma", "country":
-  "", "created": "2022-05-26T19:09:36.616724", "detections": {"benign": 0, "malicious":
+  "", "created": "2023-09-19T19:47:15.833914", "detections": {"benign": 0, "malicious":
   1, "total": 1}, "extended_type": "EICAR virus test files", "failed": false, "filename":
-  "malicious", "first_seen": "2022-05-26T16:25:31.875900", "id": "51433256212000920",
-  "last_scanned": "2022-05-26T19:09:36.616724", "last_seen": "2022-05-26T19:09:36.616724",
-  "md5": "44d88612fea8a8f36de82e1278abb02f", "metadata": [{"created": "2022-05-26T17:38:57.900531",
-  "tool": "test_tool_2", "tool_metadata": {"key2": "value2"}, "updated": "2022-05-26T17:38:57.900531"},
-  {"created": "2022-05-26T17:38:57.831542", "tool": "test_tool_1", "tool_metadata":
-  {"key": "value"}, "updated": "2022-05-26T17:38:57.831542"}, {"created": "2022-05-26T16:26:02.695665",
-  "tool": "polyunite", "tool_metadata": {"labels": [], "malware_family": null, "operating_system":
-  []}, "updated": "2022-05-26T19:28:45.767105"}, {"created": "2022-05-26T16:25:35.181822",
-  "tool": "strings", "tool_metadata": {"domains": [], "ipv4": [], "ipv6": [], "urls":
-  []}, "updated": "2022-05-26T19:28:15.806280"}, {"created": "2022-05-26T16:25:33.326291",
-  "tool": "hash", "tool_metadata": {"md5": "44d88612fea8a8f36de82e1278abb02f", "sha1":
-  "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+  "malicious", "first_seen": "2023-09-19T19:47:15.833914", "id": "79185011799085464",
+  "last_scanned": "2023-09-19T19:47:15.833914", "last_seen": "2023-09-19T19:47:15.833914",
+  "md5": "44d88612fea8a8f36de82e1278abb02f", "metadata": [{"created": "2023-09-19T19:47:46.619125",
+  "tool": "polyunite", "tool_metadata": {"labels": ["nonmalware"], "malware_family":
+  "EICAR", "operating_system": []}, "updated": "2023-09-19T19:47:46.619125"}, {"created":
+  "2023-09-19T19:47:16.275587", "tool": "hash", "tool_metadata": {"md5": "44d88612fea8a8f36de82e1278abb02f",
+  "sha1": "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
   "sha3_256": "8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8",
   "sha3_512": "a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007",
   "sha512": "cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab",
   "ssdeep": "3:a+JraNvsgzsVqSwHq9:tJuOgzsko", "tlsh": "41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},
-  "updated": "2022-05-26T19:28:15.723717"}], "mimetype": "text/plain", "polyscore":
-  0.23213458159978606, "result": null, "sha1": "3395856ce81f2b7382dee72602f798b642f14140",
-  "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "size":
-  68, "type": "FILE", "upload_url": null, "votes": [{"arbiter": "707133430915539",
-  "arbiter_name": "arbiter-eicar", "engine": {"description": "Webhook-Arbiter", "name":
-  "arbiter-eicar"}, "metadata": {"malware_family": "EICAR", "product": "eicar"}, "vote":
-  true}], "window_closed": true}
+  "updated": "2023-09-19T19:47:16.405873"}, {"created": "2023-09-19T19:47:16.275587",
+  "tool": "exiftool", "tool_metadata": {"directory": "/tmp", "exiftoolversion": 12.25,
+  "fileaccessdate": "2023:09:19 19:47:16+00:00", "fileinodechangedate": "2023:09:19
+  19:47:16+00:00", "filemodifydate": "2023:09:19 19:47:16+00:00", "filename": "tmpid_71hl2",
+  "filepermissions": "-rw-r--r--", "filesize": "68 bytes", "filetype": "TXT", "filetypeextension":
+  "txt", "linecount": 1, "mimeencoding": "us-ascii", "mimetype": "text/plain", "newlines":
+  "(none)", "sourcefile": "/tmp/tmpid_71hl2", "wordcount": 1}, "updated": "2023-09-19T19:47:16.530149"}],
+  "mimetype": "text/plain", "polyscore": 0.23213458159978606, "result": null, "sha1":
+  "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+  "size": 68, "type": "FILE", "upload_url": "http://minio:9000/instances/d8/f1/ec/d8f1ec0f-4a8c-4442-bff8-da9da04b94af?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T194715Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=f5feaaa095e51adca98764aed693269a91b2a5a236fd24ca109bc098eea920b9",
+  "votes": [{"arbiter": "490109106931282", "arbiter_name": "arbiter-eicar", "engine":
+  {"description": "Webhook-Arbiter", "name": "arbiter-eicar"}, "metadata": {"malware_family":
+  "EICAR", "product": "eicar"}, "vote": true}], "window_closed": true}
 
   '

--- a/tests/vcr/test_submission_lookup_json.vcr
+++ b/tests/vcr/test_submission_lookup_json.vcr
@@ -11,24 +11,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/51433256212000920
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/79185011799085464
   response:
     body:
-      string: '{"result":{"artifact_id":"51433256212000920","assertions":[{"author":"93822790783196","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2022-05-26T19:09:36.616724","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"51433256212000920","last_scanned":"2022-05-26T19:09:36.616724","last_seen":"2022-05-26T19:09:36.616724","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:28:45.767105"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:28:15.806280"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:28:15.723717"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"707133430915539","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+      string: '{"result":{"artifact_id":"79185011799085464","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:47:15.833914","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"79185011799085464","last_scanned":"2023-09-19T19:47:15.833914","last_seen":"2023-09-19T19:47:15.833914","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:47:46.619125","tool":"polyunite","tool_metadata":{"labels":["nonmalware"],"malware_family":"EICAR","operating_system":[]},"updated":"2023-09-19T19:47:46.619125"},{"created":"2023-09-19T19:47:16.275587","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:47:16.405873"},{"created":"2023-09-19T19:47:16.275587","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:47:16+00:00","fileinodechangedate":"2023:09:19 19:47:16+00:00","filemodifydate":"2023:09:19
+        19:47:16+00:00","filename":"tmpid_71hl2","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpid_71hl2","wordcount":1},"updated":"2023-09-19T19:47:16.530149"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/d8/f1/ec/d8f1ec0f-4a8c-4442-bff8-da9da04b94af?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T194715Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=f5feaaa095e51adca98764aed693269a91b2a5a236fd24ca109bc098eea920b9","votes":[{"arbiter":"490109106931282","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2539'
+      - '3016'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:30:03 GMT
+      - Tue, 19 Sep 2023 19:48:05 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_submission_lookup_text.click
+++ b/tests/vcr/test_submission_lookup_text.click
@@ -1,11 +1,11 @@
 result: "============================= Artifact Instance =============================\n\
-  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\n\
+  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/79185011799085464\n\
   Detections: 1/1 engines reported malicious\n\tengine-eicar: Malicious, metadata:\
-  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 51433256212000920\n\
+  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 79185011799085464\n\
   SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\nSHA1:\
   \ 3395856ce81f2b7382dee72602f798b642f14140\nMD5: 44d88612fea8a8f36de82e1278abb02f\n\
   File type: mimetype: text/plain, extended_info: EICAR virus test files\nSSDEEP:\
   \ 3:a+JraNvsgzsVqSwHq9:tJuOgzsko\nTLSH: 41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228\n\
-  First seen: 2022-05-26 16:25:31 UTC\nLast scanned: 2022-05-26 19:09:36 UTC\n\
-  Last seen: 2022-05-26 19:09:36 UTC\nStatus: Assertion window closed\nFilename:\
-  \ malicious\nCommunity: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"
+  First seen: 2023-09-19 19:47:15 UTC\nLast scanned: 2023-09-19 19:47:15 UTC\nLast\
+  \ seen: 2023-09-19 19:47:15 UTC\nStatus: Assertion window closed\nFilename: malicious\n\
+  Community: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"

--- a/tests/vcr/test_submission_lookup_text.vcr
+++ b/tests/vcr/test_submission_lookup_text.vcr
@@ -11,24 +11,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/51433256212000920
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/79185011799085464
   response:
     body:
-      string: '{"result":{"artifact_id":"51433256212000920","assertions":[{"author":"93822790783196","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2022-05-26T19:09:36.616724","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"51433256212000920","last_scanned":"2022-05-26T19:09:36.616724","last_seen":"2022-05-26T19:09:36.616724","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:28:45.767105"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:28:15.806280"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:28:15.723717"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"707133430915539","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+      string: '{"result":{"artifact_id":"79185011799085464","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:47:15.833914","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"79185011799085464","last_scanned":"2023-09-19T19:47:15.833914","last_seen":"2023-09-19T19:47:15.833914","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:47:46.619125","tool":"polyunite","tool_metadata":{"labels":["nonmalware"],"malware_family":"EICAR","operating_system":[]},"updated":"2023-09-19T19:47:46.619125"},{"created":"2023-09-19T19:47:16.275587","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:47:16.405873"},{"created":"2023-09-19T19:47:16.275587","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:47:16+00:00","fileinodechangedate":"2023:09:19 19:47:16+00:00","filemodifydate":"2023:09:19
+        19:47:16+00:00","filename":"tmpid_71hl2","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpid_71hl2","wordcount":1},"updated":"2023-09-19T19:47:16.530149"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":"http://minio:9000/instances/d8/f1/ec/d8f1ec0f-4a8c-4442-bff8-da9da04b94af?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20230919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230919T194715Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=f5feaaa095e51adca98764aed693269a91b2a5a236fd24ca109bc098eea920b9","votes":[{"arbiter":"490109106931282","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2539'
+      - '3016'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:30:03 GMT
+      - Tue, 19 Sep 2023 19:48:37 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_submission_rescan_id_json.click
+++ b/tests/vcr/test_submission_rescan_id_json.click
@@ -1,29 +1,30 @@
-result: '{"artifact_id": "86596778921560667", "assertions": [{"author": "93822790783196",
+result: '{"artifact_id": "64612150686801529", "assertions": [{"author": "321669517060332",
   "author_name": "engine-eicar", "bid": "1000000000000000000", "engine": {"description":
   "Webhook-Engine", "name": "engine-eicar"}, "mask": true, "metadata": {"malware_family":
   "EICAR", "product": "eicar"}, "verdict": true}], "community": "gamma", "country":
-  "", "created": "2022-05-26T19:28:15.551667", "detections": {"benign": 0, "malicious":
+  "", "created": "2023-09-19T19:49:39.874458", "detections": {"benign": 0, "malicious":
   1, "total": 1}, "extended_type": "EICAR virus test files", "failed": false, "filename":
-  "malicious", "first_seen": "2022-05-26T16:25:31.875900", "id": "86596778921560667",
-  "last_scanned": "2022-05-26T19:28:15.551667", "last_seen": "2022-05-26T19:28:15.551667",
-  "md5": "44d88612fea8a8f36de82e1278abb02f", "metadata": [{"created": "2022-05-26T17:38:57.900531",
-  "tool": "test_tool_2", "tool_metadata": {"key2": "value2"}, "updated": "2022-05-26T17:38:57.900531"},
-  {"created": "2022-05-26T17:38:57.831542", "tool": "test_tool_1", "tool_metadata":
-  {"key": "value"}, "updated": "2022-05-26T17:38:57.831542"}, {"created": "2022-05-26T16:26:02.695665",
-  "tool": "polyunite", "tool_metadata": {"labels": [], "malware_family": null, "operating_system":
-  []}, "updated": "2022-05-26T19:28:45.767105"}, {"created": "2022-05-26T16:25:35.181822",
-  "tool": "strings", "tool_metadata": {"domains": [], "ipv4": [], "ipv6": [], "urls":
-  []}, "updated": "2022-05-26T19:28:15.806280"}, {"created": "2022-05-26T16:25:33.326291",
-  "tool": "hash", "tool_metadata": {"md5": "44d88612fea8a8f36de82e1278abb02f", "sha1":
-  "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+  "malicious", "first_seen": "2023-09-19T19:47:15.833914", "id": "64612150686801529",
+  "last_scanned": "2023-09-19T19:49:39.874458", "last_seen": "2023-09-19T19:49:39.874458",
+  "md5": "44d88612fea8a8f36de82e1278abb02f", "metadata": [{"created": "2023-09-19T19:50:10.044447",
+  "tool": "polyunite", "tool_metadata": {"labels": ["nonmalware"], "malware_family":
+  "EICAR", "operating_system": []}, "updated": "2023-09-19T19:50:10.044447"}, {"created":
+  "2023-09-19T19:49:40.037368", "tool": "hash", "tool_metadata": {"md5": "44d88612fea8a8f36de82e1278abb02f",
+  "sha1": "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
   "sha3_256": "8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8",
   "sha3_512": "a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007",
   "sha512": "cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab",
   "ssdeep": "3:a+JraNvsgzsVqSwHq9:tJuOgzsko", "tlsh": "41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},
-  "updated": "2022-05-26T19:28:15.723717"}], "mimetype": "text/plain", "polyscore":
-  0.23213458159978606, "result": null, "sha1": "3395856ce81f2b7382dee72602f798b642f14140",
-  "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "size":
-  68, "type": "FILE", "upload_url": null, "votes": [{"arbiter": "707133430915539",
+  "updated": "2023-09-19T19:49:40.126969"}, {"created": "2023-09-19T19:49:40.037368",
+  "tool": "exiftool", "tool_metadata": {"directory": "/tmp", "exiftoolversion": 12.25,
+  "fileaccessdate": "2023:09:19 19:49:40+00:00", "fileinodechangedate": "2023:09:19
+  19:49:40+00:00", "filemodifydate": "2023:09:19 19:49:40+00:00", "filename": "tmpstxgjmxm",
+  "filepermissions": "-rw-r--r--", "filesize": "68 bytes", "filetype": "TXT", "filetypeextension":
+  "txt", "linecount": 1, "mimeencoding": "us-ascii", "mimetype": "text/plain", "newlines":
+  "(none)", "sourcefile": "/tmp/tmpstxgjmxm", "wordcount": 1}, "updated": "2023-09-19T19:49:40.246873"}],
+  "mimetype": "text/plain", "polyscore": 0.23213458159978606, "result": null, "sha1":
+  "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+  "size": 68, "type": "FILE", "upload_url": null, "votes": [{"arbiter": "490109106931282",
   "arbiter_name": "arbiter-eicar", "engine": {"description": "Webhook-Arbiter", "name":
   "arbiter-eicar"}, "metadata": {"malware_family": "EICAR", "product": "eicar"}, "vote":
   true}], "window_closed": true}

--- a/tests/vcr/test_submission_rescan_id_json.vcr
+++ b/tests/vcr/test_submission_rescan_id_json.vcr
@@ -13,24 +13,26 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: POST
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/rescan/78691987955427124
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/rescan/79185011799085464
   response:
     body:
-      string: '{"result":{"artifact_id":"86596778921560667","assertions":[],"community":"gamma","country":"","created":"2022-05-26T19:28:15.551667","detections":null,"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"86596778921560667","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:10:38.613625"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:10:08.852154"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:10:10.835393"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2020'
+      - '661'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:28:15 GMT
+      - Tue, 19 Sep 2023 19:49:40 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:
@@ -48,24 +50,1146 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/86596778921560667
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
   response:
     body:
-      string: '{"result":{"artifact_id":"86596778921560667","assertions":[{"author":"93822790783196","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2022-05-26T19:28:15.551667","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"86596778921560667","last_scanned":"2022-05-26T19:28:15.551667","last_seen":"2022-05-26T19:28:15.551667","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:28:45.767105"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:28:15.806280"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:28:15.723717"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"707133430915539","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2539'
+      - '661'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:28:45 GMT
+      - Tue, 19 Sep 2023 19:49:40 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:41 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:42 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:43 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:44 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:45 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:47 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:48 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:49 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:50 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:51 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:52 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:54 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:55 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:56 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:57 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:58 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:49:59 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:00 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:01 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:02 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:03 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:04 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:05 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"490109106931282","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2397'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:06 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"490109106931282","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2397'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:08 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"490109106931282","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2397'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:09 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/64612150686801529
+  response:
+    body:
+      string: '{"result":{"artifact_id":"64612150686801529","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:49:39.874458","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"64612150686801529","last_scanned":"2023-09-19T19:49:39.874458","last_seen":"2023-09-19T19:49:39.874458","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:50:10.044447","tool":"polyunite","tool_metadata":{"labels":["nonmalware"],"malware_family":"EICAR","operating_system":[]},"updated":"2023-09-19T19:50:10.044447"},{"created":"2023-09-19T19:49:40.037368","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:49:40.126969"},{"created":"2023-09-19T19:49:40.037368","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:49:40+00:00","fileinodechangedate":"2023:09:19 19:49:40+00:00","filemodifydate":"2023:09:19
+        19:49:40+00:00","filename":"tmpstxgjmxm","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpstxgjmxm","wordcount":1},"updated":"2023-09-19T19:49:40.246873"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"490109106931282","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2679'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:50:10 GMT
+      Server:
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_submission_rescan_id_text.click
+++ b/tests/vcr/test_submission_rescan_id_text.click
@@ -1,11 +1,11 @@
 result: "============================= Artifact Instance =============================\n\
-  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\n\
+  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/22834977959008834\n\
   Detections: 1/1 engines reported malicious\n\tengine-eicar: Malicious, metadata:\
-  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 86596778921560667\n\
+  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 22834977959008834\n\
   SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\nSHA1:\
   \ 3395856ce81f2b7382dee72602f798b642f14140\nMD5: 44d88612fea8a8f36de82e1278abb02f\n\
   File type: mimetype: text/plain, extended_info: EICAR virus test files\nSSDEEP:\
   \ 3:a+JraNvsgzsVqSwHq9:tJuOgzsko\nTLSH: 41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228\n\
-  First seen: 2022-05-26 16:25:31 UTC\nLast scanned: 2022-05-26 19:28:15 UTC\n\
-  Last seen: 2022-05-26 19:28:15 UTC\nStatus: Assertion window closed\nFilename:\
-  \ malicious\nCommunity: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"
+  First seen: 2023-09-19 19:47:15 UTC\nLast scanned: 2023-09-19 19:52:16 UTC\nLast\
+  \ seen: 2023-09-19 19:52:16 UTC\nStatus: Assertion window closed\nFilename: malicious\n\
+  Community: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"

--- a/tests/vcr/test_submission_rescan_id_text.vcr
+++ b/tests/vcr/test_submission_rescan_id_text.vcr
@@ -13,24 +13,26 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: POST
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/rescan/78691987955427124
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/rescan/79185011799085464
   response:
     body:
-      string: '{"result":{"artifact_id":"86596778921560667","assertions":[],"community":"gamma","country":"","created":"2022-05-26T19:28:15.551667","detections":null,"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"86596778921560667","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:10:38.613625"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:10:08.852154"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:10:10.835393"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2020'
+      - '661'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:28:15 GMT
+      - Tue, 19 Sep 2023 19:52:17 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:
@@ -48,24 +50,1186 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/86596778921560667
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
   response:
     body:
-      string: '{"result":{"artifact_id":"86596778921560667","assertions":[{"author":"93822790783196","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2022-05-26T19:28:15.551667","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"86596778921560667","last_scanned":"2022-05-26T19:28:15.551667","last_seen":"2022-05-26T19:28:15.551667","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:28:45.767105"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:28:15.806280"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:28:15.723717"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"707133430915539","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2539'
+      - '661'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:28:45 GMT
+      - Tue, 19 Sep 2023 19:52:17 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:18 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:19 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:20 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:21 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:22 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:23 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:24 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:25 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:26 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:27 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:28 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:30 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:31 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:32 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:33 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:34 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:35 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:36 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:37 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:38 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:39 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:40 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:41 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:42 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:43 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:44 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:45 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"490109106931282","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2397'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:47 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/22834977959008834
+  response:
+    body:
+      string: '{"result":{"artifact_id":"22834977959008834","assertions":[{"author":"321669517060332","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T19:52:16.962844","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T19:47:15.833914","id":"22834977959008834","last_scanned":"2023-09-19T19:52:16.962844","last_seen":"2023-09-19T19:52:16.962844","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T19:52:47.125524","tool":"polyunite","tool_metadata":{"labels":["nonmalware"],"malware_family":"EICAR","operating_system":[]},"updated":"2023-09-19T19:52:47.125524"},{"created":"2023-09-19T19:52:17.088527","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T19:52:17.126622"},{"created":"2023-09-19T19:52:17.088527","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        19:52:17+00:00","fileinodechangedate":"2023:09:19 19:52:17+00:00","filemodifydate":"2023:09:19
+        19:52:17+00:00","filename":"tmpjsx2f8_w","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpjsx2f8_w","wordcount":1},"updated":"2023-09-19T19:52:17.236779"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"490109106931282","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2679'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 19:52:48 GMT
+      Server:
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_submission_rescan_json.click
+++ b/tests/vcr/test_submission_rescan_json.click
@@ -1,31 +1,29 @@
-result: '{"artifact_id": "51433256212000920", "assertions": [{"author": "93822790783196",
+result: '{"artifact_id": "32237404961217137", "assertions": [{"author": "950101866283408",
   "author_name": "engine-eicar", "bid": "1000000000000000000", "engine": {"description":
   "Webhook-Engine", "name": "engine-eicar"}, "mask": true, "metadata": {"malware_family":
   "EICAR", "product": "eicar"}, "verdict": true}], "community": "gamma", "country":
-  "", "created": "2022-05-26T19:09:36.616724", "detections": {"benign": 0, "malicious":
+  "", "created": "2023-09-19T18:26:22.110418", "detections": {"benign": 0, "malicious":
   1, "total": 1}, "extended_type": "EICAR virus test files", "failed": false, "filename":
-  "malicious", "first_seen": "2022-05-26T16:25:31.875900", "id": "51433256212000920",
-  "last_scanned": "2022-05-26T19:09:36.616724", "last_seen": "2022-05-26T19:09:36.616724",
-  "md5": "44d88612fea8a8f36de82e1278abb02f", "metadata": [{"created": "2022-05-26T17:38:57.900531",
-  "tool": "test_tool_2", "tool_metadata": {"key2": "value2"}, "updated": "2022-05-26T17:38:57.900531"},
-  {"created": "2022-05-26T17:38:57.831542", "tool": "test_tool_1", "tool_metadata":
-  {"key": "value"}, "updated": "2022-05-26T17:38:57.831542"}, {"created": "2022-05-26T16:26:02.695665",
-  "tool": "polyunite", "tool_metadata": {"labels": [], "malware_family": null, "operating_system":
-  []}, "updated": "2022-05-26T19:10:06.790420"}, {"created": "2022-05-26T16:25:35.181822",
-  "tool": "strings", "tool_metadata": {"domains": [], "ipv4": [], "ipv6": [], "urls":
-  []}, "updated": "2022-05-26T19:09:36.839870"}, {"created": "2022-05-26T16:25:33.326291",
-  "tool": "hash", "tool_metadata": {"md5": "44d88612fea8a8f36de82e1278abb02f", "sha1":
-  "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+  "malicious", "first_seen": "2023-09-19T18:22:09.772806", "id": "32237404961217137",
+  "last_scanned": "2023-09-19T18:26:22.110418", "last_seen": "2023-09-19T18:26:22.110418",
+  "md5": "44d88612fea8a8f36de82e1278abb02f", "metadata": [{"created": "2023-09-19T18:26:52.233632",
+  "tool": "polyunite", "tool_metadata": {"labels": ["nonmalware"], "malware_family":
+  "EICAR", "operating_system": []}, "updated": "2023-09-19T18:26:52.233632"}, {"created":
+  "2023-09-19T18:26:22.281638", "tool": "hash", "tool_metadata": {"md5": "44d88612fea8a8f36de82e1278abb02f",
+  "sha1": "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
   "sha3_256": "8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8",
   "sha3_512": "a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007",
   "sha512": "cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab",
   "ssdeep": "3:a+JraNvsgzsVqSwHq9:tJuOgzsko", "tlsh": "41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},
-  "updated": "2022-05-26T19:09:36.764891"}], "mimetype": "text/plain", "polyscore":
-  0.23213458159978606, "result": null, "sha1": "3395856ce81f2b7382dee72602f798b642f14140",
-  "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "size":
-  68, "type": "FILE", "upload_url": null, "votes": [{"arbiter": "707133430915539",
-  "arbiter_name": "arbiter-eicar", "engine": {"description": "Webhook-Arbiter", "name":
-  "arbiter-eicar"}, "metadata": {"malware_family": "EICAR", "product": "eicar"}, "vote":
-  true}], "window_closed": true}
+  "updated": "2023-09-19T18:26:22.382261"}, {"created": "2023-09-19T18:26:22.281638",
+  "tool": "exiftool", "tool_metadata": {"directory": "/tmp", "exiftoolversion": 12.25,
+  "fileaccessdate": "2023:09:19 18:26:22+00:00", "fileinodechangedate": "2023:09:19
+  18:26:22+00:00", "filemodifydate": "2023:09:19 18:26:22+00:00", "filename": "tmp947460ux",
+  "filepermissions": "-rw-r--r--", "filesize": "68 bytes", "filetype": "TXT", "filetypeextension":
+  "txt", "linecount": 1, "mimeencoding": "us-ascii", "mimetype": "text/plain", "newlines":
+  "(none)", "sourcefile": "/tmp/tmp947460ux", "wordcount": 1}, "updated": "2023-09-19T18:26:22.488829"}],
+  "mimetype": "text/plain", "polyscore": 0.23213458159978606, "result": null, "sha1":
+  "3395856ce81f2b7382dee72602f798b642f14140", "sha256": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+  "size": 68, "type": "FILE", "upload_url": null, "votes": [], "window_closed": true}
 
   '

--- a/tests/vcr/test_submission_rescan_json.vcr
+++ b/tests/vcr/test_submission_rescan_json.vcr
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: null
+    body: community=gamma
     headers:
       Accept:
       - '*/*'
@@ -11,26 +11,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '0'
+      - '15'
+      Content-Type:
+      - application/x-www-form-urlencoded
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: POST
     uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/rescan/sha256/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
   response:
     body:
-      string: '{"result":{"artifact_id":"51433256212000920","assertions":[],"community":"gamma","country":"","created":"2022-05-26T19:09:36.616724","detections":null,"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"51433256212000920","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:09:34.312408"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:09:04.340093"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:09:04.276188"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2020'
+      - '661'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:09:36 GMT
+      - Tue, 19 Sep 2023 18:26:22 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:
@@ -48,24 +52,1146 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/51433256212000920
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
   response:
     body:
-      string: '{"result":{"artifact_id":"51433256212000920","assertions":[{"author":"93822790783196","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2022-05-26T19:09:36.616724","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"51433256212000920","last_scanned":"2022-05-26T19:09:36.616724","last_seen":"2022-05-26T19:09:36.616724","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:10:06.790420"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:09:36.839870"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:09:36.764891"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"707133430915539","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2539'
+      - '661'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:10:07 GMT
+      - Tue, 19 Sep 2023 18:26:22 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:23 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:24 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:25 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:26 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:27 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:28 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:29 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:31 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:32 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:33 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:34 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:35 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:36 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:37 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:38 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:39 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:40 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:41 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:42 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:44 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:45 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:46 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:47 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:48 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:49 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:50 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:51 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/32237404961217137
+  response:
+    body:
+      string: '{"result":{"artifact_id":"32237404961217137","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:22.110418","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"32237404961217137","last_scanned":"2023-09-19T18:26:22.110418","last_seen":"2023-09-19T18:26:22.110418","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.233632","tool":"polyunite","tool_metadata":{"labels":["nonmalware"],"malware_family":"EICAR","operating_system":[]},"updated":"2023-09-19T18:26:52.233632"},{"created":"2023-09-19T18:26:22.281638","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:22.382261"},{"created":"2023-09-19T18:26:22.281638","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:22+00:00","fileinodechangedate":"2023:09:19 18:26:22+00:00","filemodifydate":"2023:09:19
+        18:26:22+00:00","filename":"tmp947460ux","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmp947460ux","wordcount":1},"updated":"2023-09-19T18:26:22.488829"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":true},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2485'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:52 GMT
+      Server:
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:

--- a/tests/vcr/test_submission_rescan_text.click
+++ b/tests/vcr/test_submission_rescan_text.click
@@ -1,11 +1,11 @@
 result: "============================= Artifact Instance =============================\n\
-  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\n\
+  Scan permalink: https://polyswarm.network/scan/results/file/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/31731181169228606\n\
   Detections: 1/1 engines reported malicious\n\tengine-eicar: Malicious, metadata:\
-  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 51433256212000920\n\
+  \ {\"malware_family\": \"EICAR\", \"product\": \"eicar\"}\nScan id: 31731181169228606\n\
   SHA256: 275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f\nSHA1:\
   \ 3395856ce81f2b7382dee72602f798b642f14140\nMD5: 44d88612fea8a8f36de82e1278abb02f\n\
   File type: mimetype: text/plain, extended_info: EICAR virus test files\nSSDEEP:\
   \ 3:a+JraNvsgzsVqSwHq9:tJuOgzsko\nTLSH: 41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228\n\
-  First seen: 2022-05-26 16:25:31 UTC\nLast scanned: 2022-05-26 19:09:36 UTC\n\
-  Last seen: 2022-05-26 19:09:36 UTC\nStatus: Assertion window closed\nFilename:\
-  \ malicious\nCommunity: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"
+  First seen: 2023-09-19 18:22:09 UTC\nLast scanned: 2023-09-19 18:26:52 UTC\nLast\
+  \ seen: 2023-09-19 18:26:52 UTC\nStatus: Assertion window closed\nFilename: malicious\n\
+  Community: gamma\nCountry: \nPolyScore: 0.23213458159978606066\n\n"

--- a/tests/vcr/test_submission_rescan_text.vcr
+++ b/tests/vcr/test_submission_rescan_text.vcr
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: null
+    body: community=gamma
     headers:
       Accept:
       - '*/*'
@@ -11,26 +11,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '0'
+      - '15'
+      Content-Type:
+      - application/x-www-form-urlencoded
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: POST
     uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/rescan/sha256/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f
   response:
     body:
-      string: '{"result":{"artifact_id":"51433256212000920","assertions":[],"community":"gamma","country":"","created":"2022-05-26T19:09:36.616724","detections":null,"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"51433256212000920","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:09:34.312408"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:09:04.340093"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:09:04.276188"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2020'
+      - '661'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:09:36 GMT
+      - Tue, 19 Sep 2023 18:26:52 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:
@@ -48,24 +52,1186 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - polyswarm-api/3.0.0 (x86_64-Linux-CPython-3.6.5)
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
     method: GET
-    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/51433256212000920
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
   response:
     body:
-      string: '{"result":{"artifact_id":"51433256212000920","assertions":[{"author":"93822790783196","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2022-05-26T19:09:36.616724","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
-        virus test files","failed":false,"filename":"malicious","first_seen":"2022-05-26T16:25:31.875900","id":"51433256212000920","last_scanned":"2022-05-26T19:09:36.616724","last_seen":"2022-05-26T19:09:36.616724","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2022-05-26T17:38:57.900531","tool":"test_tool_2","tool_metadata":{"key2":"value2"},"updated":"2022-05-26T17:38:57.900531"},{"created":"2022-05-26T17:38:57.831542","tool":"test_tool_1","tool_metadata":{"key":"value"},"updated":"2022-05-26T17:38:57.831542"},{"created":"2022-05-26T16:26:02.695665","tool":"polyunite","tool_metadata":{"labels":[],"malware_family":null,"operating_system":[]},"updated":"2022-05-26T19:10:06.790420"},{"created":"2022-05-26T16:25:35.181822","tool":"strings","tool_metadata":{"domains":[],"ipv4":[],"ipv6":[],"urls":[]},"updated":"2022-05-26T19:09:36.839870"},{"created":"2022-05-26T16:25:33.326291","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2022-05-26T19:09:36.764891"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[{"arbiter":"707133430915539","arbiter_name":"arbiter-eicar","engine":{"description":"Webhook-Arbiter","name":"arbiter-eicar"},"metadata":{"malware_family":"EICAR","product":"eicar"},"vote":true}],"window_closed":true},"status":"OK"}
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
 
         '
     headers:
+      Connection:
+      - keep-alive
       Content-Length:
-      - '2539'
+      - '661'
       Content-Type:
       - application/json
       Date:
-      - Thu, 26 May 2022 19:10:07 GMT
+      - Tue, 19 Sep 2023 18:26:52 GMT
       Server:
-      - Werkzeug/1.0.1 Python/3.9.6
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:53 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:55 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:56 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:57 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:58 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:26:59 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:00 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:01 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:02 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:03 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:04 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:05 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:06 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:07 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:08 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:09 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:11 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:12 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:13 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:14 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:15 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:16 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:17 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:18 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:19 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:20 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:21 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":null,"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":null,"last_seen":null,"md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":null,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":false},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2203'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:22 GMT
+      Server:
+      - gunicorn
+      X-Billing-ID:
+      - '1'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - '11111111111111111111111111111111'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - polyswarm-api/3.4.3.dev0+20230918233132 (x86_64-Linux-CPython-3.9.10)
+    method: GET
+    uri: http://artifact-index-e2e:9696/v3/consumer/submission/gamma/31731181169228606
+  response:
+    body:
+      string: '{"result":{"artifact_id":"31731181169228606","assertions":[{"author":"950101866283408","author_name":"engine-eicar","bid":"1000000000000000000","engine":{"description":"Webhook-Engine","name":"engine-eicar"},"mask":true,"metadata":{"malware_family":"EICAR","product":"eicar"},"verdict":true}],"community":"gamma","country":"","created":"2023-09-19T18:26:52.733575","detections":{"benign":0,"malicious":1,"total":1},"extended_type":"EICAR
+        virus test files","failed":false,"filename":"malicious","first_seen":"2023-09-19T18:22:09.772806","id":"31731181169228606","last_scanned":"2023-09-19T18:26:52.733575","last_seen":"2023-09-19T18:26:52.733575","md5":"44d88612fea8a8f36de82e1278abb02f","metadata":[{"created":"2023-09-19T18:27:22.885312","tool":"polyunite","tool_metadata":{"labels":["nonmalware"],"malware_family":"EICAR","operating_system":[]},"updated":"2023-09-19T18:27:22.885312"},{"created":"2023-09-19T18:26:52.781872","tool":"hash","tool_metadata":{"md5":"44d88612fea8a8f36de82e1278abb02f","sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","sha3_256":"8b4c4e204a8a039198e292d2291f4c451d80e4c38bf0cc04ad3841fea8755bd8","sha3_512":"a20290c6ebf01dc5182bb57718250f61ab11b418466714632a7d1474a02849641f7b78e4093e19ad12fdbedbe02f3bec4ca3ec3235557e82ab5ac02d061e7007","sha512":"cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab","ssdeep":"3:a+JraNvsgzsVqSwHq9:tJuOgzsko","tlsh":"41a022003b0eee2ba20b00200032e8b00808020e2ce00a3820a020b8c83308803ec228"},"updated":"2023-09-19T18:26:52.886647"},{"created":"2023-09-19T18:26:52.781872","tool":"exiftool","tool_metadata":{"directory":"/tmp","exiftoolversion":12.25,"fileaccessdate":"2023:09:19
+        18:26:52+00:00","fileinodechangedate":"2023:09:19 18:26:52+00:00","filemodifydate":"2023:09:19
+        18:26:52+00:00","filename":"tmpy3rd167a","filepermissions":"-rw-r--r--","filesize":"68
+        bytes","filetype":"TXT","filetypeextension":"txt","linecount":1,"mimeencoding":"us-ascii","mimetype":"text/plain","newlines":"(none)","sourcefile":"/tmp/tmpy3rd167a","wordcount":1},"updated":"2023-09-19T18:26:52.991876"}],"mimetype":"text/plain","polyscore":0.23213458159978606,"result":null,"sha1":"3395856ce81f2b7382dee72602f798b642f14140","sha256":"275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f","size":68,"type":"FILE","upload_url":null,"votes":[],"window_closed":true},"status":"OK"}
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2485'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Sep 2023 18:27:23 GMT
+      Server:
+      - gunicorn
       X-Billing-ID:
       - '1'
     status:


### PR DESCRIPTION
To get the tests passing I had to update a few test vcr files, I think because of changes related to the permalinks.  There is also one test I still couldn't get passing in CI: `test_download_cat` but it does pass locally.