### PR TITLE
DN6538 - ioc-beta

### DIFF
--- a/src/polyswarm/client/search.py
+++ b/src/polyswarm/client/search.py
@@ -81,8 +81,9 @@ def metadata(ctx, query_string, include, exclude, ip, url, domain):
 @click.argument('type',  required=True,
                 type=click.Choice(['ip', 'domain', 'ttp', 'imphash', 'sha256', 'sha1', 'md5'], case_sensitive=False))
 @click.argument('value', required=True)
+@click.option('-b', '--beta', type=click.BOOL, is_flag=True)
 @click.pass_context
-def iocs_by_hash(ctx, type, value, hide_known_good):
+def iocs_by_hash(ctx, type, value, hide_known_good, beta):
     """
     Provide an artifact hash to get the associated IOCs.
     """
@@ -102,7 +103,7 @@ def iocs_by_hash(ctx, type, value, hide_known_good):
         for result in api.search_by_ioc(**params):
             output.ioc(result)
     else:
-        output.ioc(api.iocs_by_hash(type, value, hide_known_good=hide_known_good))
+        output.ioc(api.iocs_by_hash(type, value, hide_known_good=hide_known_good, beta=beta))
 
 
 @search.command('known', short_help='Check if host is known.')
@@ -124,15 +125,19 @@ def search_known(ctx, ip, domain):
 @click.argument('type', required=True)
 @click.argument('host', required=True)
 @click.argument('source', required=True)
+@click.option('-g', '--good', type=click.BOOL, default=True)
 @click.pass_context
-def add(ctx, type, host, source):
+def add(ctx, type, host, source, good):
     """
     Add a known good ip or domain.
     """
     api = ctx.obj['api']
     output = ctx.obj['output']
 
-    output.known_host(api.add_known_good_host(type, source, host))
+    if good:
+        output.known_host(api.add_known_good_host(type, source, host))
+    else:
+        output.known_host(api.add_known_bad_host(type, source, host))
 
 
 @known.command('update', short_help='Update a known host.')

--- a/src/polyswarm/formatters/json.py
+++ b/src/polyswarm/formatters/json.py
@@ -134,7 +134,7 @@ class JSONOutput(base.BaseOutput):
     def iocs(self, results):
         click.echo(self._to_json([result.json for result in results]), file=self.out)
 
-    def ioc(self, result):
+    def ioc(self, result, beta=None):
         click.echo(self._to_json(result.json), file=self.out)
 
     def known_host(self, result):

--- a/src/polyswarm/formatters/json.py
+++ b/src/polyswarm/formatters/json.py
@@ -134,7 +134,7 @@ class JSONOutput(base.BaseOutput):
     def iocs(self, results):
         click.echo(self._to_json([result.json for result in results]), file=self.out)
 
-    def ioc(self, result, beta=None):
+    def ioc(self, result):
         click.echo(self._to_json(result.json), file=self.out)
 
     def known_host(self, result):


### PR DESCRIPTION
confidence values are color coded similar to polyscore
```
$ polyswarm -u $URL -a $KEY search ioc sha256 4bbd11e6ca75f4feadf22a1726d0e2dc85b35fd600434fbe20688bce534b824f -b
============================= IOC =============================
Malware Family: pony
PolyScore: 0.99999624170776846288
ImpHash: bd3825b6e0410966f0c31f64b6c7644a
TTPs: T1202, T1562, T1552.001, T1539, T1497, T1518, T1053, T1573, T1082, T1564, T1005, T1547, T1003, T1112, T1562.001, T1547.001, T1057, T1552, T1071, T1564.001, T1059, T1496, T1012, T1564.003, T1114
IPs:
	185.79.156.18
		confidence: 99
		ports: []
	132.163.97.1
		confidence: 0
		ports: []
	193.138.218.74
		confidence: 0
		ports: []
	132.163.96.6
		confidence: 0
		ports: []
	2.17.197.249
		confidence: 0
		ports: []
Domains:
URLs:
	http://185.79.156.18
		confidence: 99
	http://185.79.156.18/bit/03/gate.php
		confidence: 99
```