### PR TITLE
Wait for report and download

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license='MIT',
     python_requires='>=3.7,<4',
     install_requires=[
-        'polyswarm-api~=3.7.0.dev',
+        'polyswarm-api~=3.7.1.dev',
         'click~=7.1',
         'colorama~=0.4.6',
         'click-log~=0.4.0',

--- a/src/polyswarm/client/report.py
+++ b/src/polyswarm/client/report.py
@@ -44,15 +44,15 @@ def create(ctx, format, type, object_id, template_id, includes, nowait, timeout,
                                format=format,
                                template_id=template_id,
                                template_metadata=template_metadata or None,
-                               nowait=nowait,
-                               timeout=timeout,
-                               destination=destination,
                                **object_d)
-    if isinstance(result, resources.ReportTask):
+    if nowait:
         output.report_task(result)
     else:
-        # LocalArtifact downloaded
-        output.local_artifact(result)
+        _report = api.report_wait_for(result.id, timeout)
+        if destination:
+            result = _report.download_report(folder=destination).result()
+            result.handle.close()
+            output.local_artifact(result)
 
 
 @report.command('get', short_help='Fetch a report task for an instance or sandbox id.')

--- a/src/polyswarm/client/report.py
+++ b/src/polyswarm/client/report.py
@@ -3,8 +3,8 @@ import os
 
 import click
 
-
 from polyswarm.client import utils
+from polyswarm_api import settings, resources
 
 logger = logging.getLogger(__name__)
 
@@ -26,19 +26,33 @@ SECTIONS = "summary, detections, fileMetadata, network, droppedFiles, extractedC
               help=f'Comma-separated list of sections to include in the report. Can be one ore more of: {SECTIONS}',
               multiple=True,
               callback=lambda _,o,x: x[0].split(',') if len(x) == 1 else x)
+@click.option('-n', '--nowait', is_flag=True,
+              help='Does not wait for the report generation to finish, just create it and return right away.')
+@click.option('-t', '--timeout', type=click.INT, default=settings.DEFAULT_REPORT_TIMEOUT,
+              help=f'How long to wait for results.', show_default=True)
+@click.option('-d', '--destination', type=click.Path(file_okay=False),
+              help='Path where to store the downloaded report.', default=os.getcwd())
 @click.pass_context
-def create(ctx, format, type, object_id, template_id, includes):
+def create(ctx, format, type, object_id, template_id, includes, nowait, timeout, destination):
     api = ctx.obj['api']
     output = ctx.obj['output']
     object_d = {'instance_id': object_id} if type == 'scan' else {'sandbox_task_id': object_id}
     template_metadata = {}
     if includes:
         template_metadata['includes'] = includes
-    output.report_task(api.report_create(type=type,
-                                         format=format,
-                                         template_id=template_id,
-                                         template_metadata=template_metadata or None,
-                                         **object_d))
+    result = api.report_create(type=type,
+                               format=format,
+                               template_id=template_id,
+                               template_metadata=template_metadata or None,
+                               nowait=nowait,
+                               timeout=timeout,
+                               destination=destination,
+                               **object_d)
+    if isinstance(result, resources.ReportTask):
+        output.report_task(result)
+    else:
+        # LocalArtifact downloaded
+        output.local_artifact(result)
 
 
 @report.command('get', short_help='Fetch a report task for an instance or sandbox id.')

--- a/src/polyswarm/client/utils.py
+++ b/src/polyswarm/client/utils.py
@@ -1,5 +1,6 @@
 import logging
 import functools
+import sys
 
 import click
 
@@ -55,8 +56,12 @@ def validate_hashes(ctx, param, value):
 
 def validate_key(ctx, param, value):
     if not resources.core.is_hex(value) or len(value) != 32:
-        raise click.BadParameter(
-            'Invalid API key. Make sure you specified your key via -a or environment variable and try again.')
+        if all(     # workaround for the inability of Click to process the -h/--help argument first
+                map(lambda x: x not in ctx.help_option_names, sys.argv)
+        ):
+            raise click.BadParameter(
+                f'Invalid API key. Make sure you specified your key via {", ".join(param.opts)} option, '
+                f'or through the environment variable {param.envvar} and try again.')
     return value
 
 


### PR DESCRIPTION
Optionally the user can opt out.

API changes: https://github.com/polyswarm/polyswarm-api/pull/237

Also fix the issue with the CLI asking an API Key when the user only wants to execute `--help` of a command. It's a workaround, because the Click library does not allow to skip the execution of parent commands, sadly it's a well know issue reported by many users but not fixed.