### PR TITLE
Preprocessing field for zip sandbox submissions

### DIFF
--- a/src/polyswarm/client/sandbox.py
+++ b/src/polyswarm/client/sandbox.py
@@ -119,43 +119,46 @@ def task_status(ctx, sandbox_task_id):
 
 
 @sandbox.command('lookup', short_help='Lookup the latest sandbox results for a hash.')
-@click.argument('sandbox_', type=click.STRING, required=True)
+@click.argument('provider', type=click.STRING, required=True)
 @click.argument('sha256', type=click.STRING, required=True)
 @click.pass_context
-def task_latest(ctx, sha256, sandbox_):
+def task_latest(ctx, sha256, provider):
     """
-    Lookup the latest results of sandbox data for the tuple (hash, community, sandbox name).
+    Lookup the latest results of sandbox data for the tuple (SHA256, community, sandbox PROVIDER name).
     """
     api = ctx.obj['api']
     output = ctx.obj['output']
 
-    output.sandbox_task(api.sandbox_task_latest(sha256, sandbox_))
+    output.sandbox_task(api.sandbox_task_latest(sha256, provider))
 
 
 @sandbox.command('search', short_help='Search for all the sandbox results for a hash.')
 @click.argument('sha256', type=click.STRING, required=True)
-@click.option('--sandbox', 'sandbox_', type=click.STRING, help='Filter by slug of the sandbox provider')
-@click.option('--start-date', 'start_date', type=click.STRING)
-@click.option('--end-date', 'end_date', type=click.STRING)
+@click.option('--provider', type=click.STRING, help='Filter by slug of the sandbox provider')
+@click.option('--start-date', 'start_date', type=click.STRING,
+              help='Tasks created the day passed or after (ISO format).')
+@click.option('--end-date', 'end_date', type=click.STRING,
+              help='Tasks created the day passed or before (ISO format).')
 @click.option('--status', 'status', type=click.STRING)
 @click.option('--account-id', 'account_id', type=click.STRING)
 @click.pass_context
-def task_list(ctx, sha256, sandbox_, start_date, end_date, status, account_id):
+def task_list(ctx, sha256, provider, start_date, end_date, status, account_id):
     """
-    Search for all the sandbox results identified by the tuple (hash, community, [sandbox], [start_date], [end_date], [status]).
+    Search for all the sandbox results identified by the tuple (SHA256, community, [sandbox PROVIDER name],
+    [start_date], [end_date], [status]).
     """
     api = ctx.obj['api']
     output = ctx.obj['output']
 
-    for task in api.sandbox_task_list(sha256, sandbox=sandbox_, start_date=start_date, end_date=end_date, status=status,
+    for task in api.sandbox_task_list(sha256, sandbox=provider, start_date=start_date, end_date=end_date, status=status,
                                       account_id=account_id):
         output.sandbox_task(task)
 
 
 @sandbox.command('my-tasks', short_help='Search for all the sandbox results created by my account or team.')
 @click.option('--provider', 'sandbox_', type=click.STRING, help='Filter by slug of the sandbox provider.')
-@click.option('--start-date', type=click.STRING, help='List tasks created the day passed or after (ISO format).')
-@click.option('--end-date', type=click.STRING, help='List tasks created the day passed or before (ISO format).')
+@click.option('--start-date', type=click.STRING, help='Tasks created the day passed or after (ISO format).')
+@click.option('--end-date', type=click.STRING, help='Tasks created the day passed or before (ISO format).')
 @click.option('--sha256', type=click.STRING, help='Only list tasks with the SHA256 passed.')
 @click.pass_context
 def my_task_list(ctx, sandbox_, start_date, end_date, sha256):

--- a/src/polyswarm/client/sandbox.py
+++ b/src/polyswarm/client/sandbox.py
@@ -47,9 +47,15 @@ def file(ctx, path, sandbox, vm_slug, internet_disabled, is_zip, zip_password):
     """
     api = ctx.obj['api']
     output = ctx.obj['output']
-
+    if is_zip or zip_password:
+        preprocessing = {'type': 'zip'}
+        if zip_password:
+            preprocessing['password'] = zip_password
+    else:
+        preprocessing = None
     output.sandbox_task(api.sandbox_file(path, sandbox, vm_slug, network_enabled=not internet_disabled,
-                                         is_zip=is_zip, zip_password=zip_password))
+                                         preprocessing=preprocessing))
+
 
 @sandbox.command('url', short_help='Submit a url to be sandboxed.')
 @click.argument('sandbox', type=click.STRING)

--- a/src/polyswarm/client/sandbox.py
+++ b/src/polyswarm/client/sandbox.py
@@ -153,10 +153,10 @@ def task_list(ctx, sha256, sandbox_, start_date, end_date, status, account_id):
 
 
 @sandbox.command('my-tasks', short_help='Search for all the sandbox results created by my account or team.')
-@click.option('--sandbox', 'sandbox_', type=click.STRING, help='Filter by slug of the sandbox provider')
-@click.option('--start-date', type=click.STRING)
-@click.option('--end-date', type=click.STRING)
-@click.option('--sha256', type=click.STRING)
+@click.option('--provider', 'sandbox_', type=click.STRING, help='Filter by slug of the sandbox provider.')
+@click.option('--start-date', type=click.STRING, help='List tasks created the day passed or after (ISO format).')
+@click.option('--end-date', type=click.STRING, help='List tasks created the day passed or before (ISO format).')
+@click.option('--sha256', type=click.STRING, help='Only list tasks with the SHA256 passed.')
 @click.pass_context
 def my_task_list(ctx, sandbox_, start_date, end_date, sha256):
     """

--- a/src/polyswarm/client/sandbox.py
+++ b/src/polyswarm/client/sandbox.py
@@ -59,18 +59,33 @@ def file(ctx, path, sandbox, vm_slug, internet_disabled, is_zip, zip_password):
 
 @sandbox.command('url', short_help='Submit a url to be sandboxed.')
 @click.argument('sandbox', type=click.STRING)
-@click.argument('url', type=click.STRING, required=True)
+@click.argument('url', type=click.STRING, required=False)
+@click.option('--qrcode-file', type=click.Path(exists=True),
+              help='QR Code image file with the URL as payload.')
 @click.option('--vm_slug', 'vm_slug', type=click.STRING)
 @click.option('--browser', 'browser', type=click.STRING)
 @click.pass_context
-def url(ctx, url, sandbox, vm_slug, browser):
+@utils.any_provided('url', 'qrcode_file')
+def url(ctx, url, qrcode_file, sandbox, vm_slug, browser):
     """
-    Submit a url to be sandboxed.
+    Submit an url to be sandboxed.
     """
+    if qrcode_file:
+        if url:
+            raise click.BadArgumentUsage('--qrcode-file cannot be used with URL.')
+        preprocessing = {'type': 'qrcode'}
+    else:
+        preprocessing = None
     api = ctx.obj['api']
     output = ctx.obj['output']
 
-    output.sandbox_task(api.sandbox_url(url, sandbox, vm_slug, browser=browser))
+    output.sandbox_task(api.sandbox_url(url,
+                                        sandbox,
+                                        vm_slug,
+                                        artifact=qrcode_file,
+                                        artifact_name=qrcode_file,
+                                        preprocessing=preprocessing,
+                                        browser=browser))
 
 
 @sandbox.command('providers', short_help='List the names of available sandboxes.')

--- a/src/polyswarm/client/scan.py
+++ b/src/polyswarm/client/scan.py
@@ -45,7 +45,7 @@ def file(ctx, recursive, timeout, nowait, path, scan_config, is_zip, zip_passwor
 
 
 @scan.command('url', short_help='Scan url.')
-@click.option('--from-qrcode', type=click.Path(exists=True),
+@click.option('--qrcode-file', type=click.Path(exists=True),
               help='QR Code image file with the URL to scan as payload.')
 @click.option('-r', '--url-file', help='File of URLs, one per line.', type=click.File('r'))
 @click.option('-t', '--timeout', type=click.INT, default=settings.DEFAULT_SCAN_TIMEOUT,
@@ -56,17 +56,17 @@ def file(ctx, recursive, timeout, nowait, path, scan_config, is_zip, zip_passwor
               help='Configuration template to be used in the scan. E.g.: "default", "more-time", "most-time".')
 @click.argument('url', nargs=-1, type=click.STRING)
 @click.pass_context
-@utils.any_provided('url', 'url_file', 'from_qrcode')
-def url_(ctx, from_qrcode, url_file, timeout, nowait, url, scan_config):
+@utils.any_provided('url', 'url_file', 'qrcode_file')
+def url_(ctx, qrcode_file, url_file, timeout, nowait, url, scan_config):
     """
     Scan files or directories via PolySwarm
     """
     api = ctx.obj['api']
     output = ctx.obj['output']
-    if from_qrcode:
+    if qrcode_file:
         if url or url_file:
-            raise click.BadArgumentUsage('--from-qrcode cannot be used with URL or -r, --url-file arguments.')
-        urls = [from_qrcode]
+            raise click.BadArgumentUsage('--qrcode-file cannot be used with URL or -r, --url-file arguments.')
+        urls = [qrcode_file]
         preprocessing = {'type': 'qrcode'}
     else:
         urls = list(url)

--- a/src/polyswarm/formatters/text.py
+++ b/src/polyswarm/formatters/text.py
@@ -347,21 +347,26 @@ class TextOutput(base.BaseOutput):
     def sandbox_task(self, task, write=True):
         output = []
         output.append(self._white('============================= Sandbox Task ============================='))
-        output.append(self._blue(f'id: {task.id}'))
-        output.append(self._blue(f'sha256: {task.sha256}'))
-        output.append(self._blue(f'sandbox: {task.sandbox}'))
-        output.append(self._white(f'created: {task.created}'))
-        output.append(self._white(f'community: {task.community}'))
-        output.append(self._white(f'instance id: {task.instance_id}'))
-        output.append(self._white(f'status: {task.status}'))
+        output.append(self._blue(f'ID: {task.id}'))
+        output.append(self._blue(f'SHA256: {task.sha256}'))
+        output.append(self._white(f'Sandbox Provider: {task.sandbox}'))
+        output.append(self._white(f'Created: {task.created}'))
+        output.append(self._white(f'Community: {task.community}'))
+        output.append(self._white(f'Instance ID: {task.instance_id}'))
+        if task.status in ('FAILED', 'FAILED_REIMBURSED', 'TIMEDOUT_REIMBURSED', 'TIMEDOUT'):
+            output.append(self._red(f'Status: {task.status}'))
+        elif task.status == 'SUCCEEDED':
+            output.append(self._green(f'Status: {task.status}'))
+        else:
+            output.append(self._yellow(f'Status: {task.status}'))
 
         if task.account_number:
-            output.append(self._white(f'account number: {task.account_number}'))
+            output.append(self._white(f'Account Number: {task.account_number}'))
         if task.team_account_number:
-            output.append(self._white(f'team account number: {task.team_account_number}'))
+            output.append(self._white(f'Team Account Number: {task.team_account_number}'))
 
         if task.sandbox_artifacts:
-            output.append(self._white('sandbox artifacts:'))
+            output.append(self._white('Sandbox Artifacts:'))
         self._open_group()
         for artifact in task.sandbox_artifacts:
             output_string = f'{artifact.type}: '
@@ -369,7 +374,7 @@ class TextOutput(base.BaseOutput):
                 output_string += f'{artifact.name}, '
             if artifact.mimetype:
                 output_string += f'{artifact.mimetype}, '
-            output_string += f'instance id: {artifact.instance_id}'
+            output_string += f'Instance ID: {artifact.instance_id}'
             output.append(self._white(output_string))
         self._close_group()
 


### PR DESCRIPTION
Issue: [DN-6979](https://polyswarm.atlassian.net/browse/DN-6979)

Python API changes: https://github.com/polyswarm/polyswarm-api/pull/242

- Support QR Code sandbox submissions with `polyswarm sandbox url --qrcode-file FILE`.
- Fix `--help` command texts
  - Add more help texts and improve others.
  - Rename the positional argument `SANDBOX` to `PROVIDER`, that hints better what is the argument for (it doesn't break any script because it's a positional argument).
  - Rename the argument `--from-qrcode` to `--qrcode-file` for scan QR Codes (it doesn't break any script because `--from-qrcode` was not released to master yet).
  - Rename arguments `--sandbox` to `--provider`, that hints better what is the argument for (it does break existing scripts, although these flags are unlikely to be used by customers, at least in automated scripts).