### PR TITLE
Validate URL argument

### DIFF
--- a/src/polyswarm/client/sandbox.py
+++ b/src/polyswarm/client/sandbox.py
@@ -81,7 +81,8 @@ def url(ctx, url, qrcode_file, provider, vm_slug, browser):
     else:
         preprocessing = None
         if url and not is_url(url):
-            raise click.BadArgumentUsage(f'URL "{url}" is not valid.')
+            raise click.BadArgumentUsage(f'URL "{url}" is not valid. '
+                                         'Make sure the protocol "https://" or "http://" is set.')
     api = ctx.obj['api']
     output = ctx.obj['output']
     output.sandbox_task(api.sandbox_url(url,

--- a/src/polyswarm/client/sandbox.py
+++ b/src/polyswarm/client/sandbox.py
@@ -4,6 +4,7 @@ import click
 
 
 from polyswarm.client import utils
+from polyswarm.utils import is_url
 
 logger = logging.getLogger(__name__)
 
@@ -79,9 +80,10 @@ def url(ctx, url, qrcode_file, provider, vm_slug, browser):
         preprocessing = {'type': 'qrcode'}
     else:
         preprocessing = None
+        if url and not is_url(url):
+            raise click.BadArgumentUsage(f'URL "{url}" is not valid.')
     api = ctx.obj['api']
     output = ctx.obj['output']
-
     output.sandbox_task(api.sandbox_url(url,
                                         provider,
                                         vm_slug,

--- a/src/polyswarm/client/scan.py
+++ b/src/polyswarm/client/scan.py
@@ -5,6 +5,7 @@ import click
 from polyswarm_api import settings
 
 from polyswarm.client import utils
+from polyswarm.utils import is_url
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,9 @@ def url_(ctx, qrcode_file, url_file, timeout, nowait, url, scan_config):
         urls = list(url)
         if url_file:
             urls.extend([u.strip() for u in url_file.readlines()])
+        for _url in url:
+            if not is_url(_url):
+                raise click.BadArgumentUsage(f'URL "{_url}" is not valid.')
         preprocessing = None
     for instance in api.scan_url(urls, timeout, nowait, scan_config, preprocessing):
         output.artifact_instance(instance)

--- a/src/polyswarm/client/scan.py
+++ b/src/polyswarm/client/scan.py
@@ -75,7 +75,8 @@ def url_(ctx, qrcode_file, url_file, timeout, nowait, url, scan_config):
             urls.extend([u.strip() for u in url_file.readlines()])
         for _url in url:
             if not is_url(_url):
-                raise click.BadArgumentUsage(f'URL "{_url}" is not valid.')
+                raise click.BadArgumentUsage(f'URL "{_url}" is not valid. '
+                                             'Make sure the protocol "https://" or "http://" is set.')
         preprocessing = None
     for instance in api.scan_url(urls, timeout, nowait, scan_config, preprocessing):
         output.artifact_instance(instance)

--- a/src/polyswarm/utils.py
+++ b/src/polyswarm/utils.py
@@ -1,5 +1,7 @@
+import ipaddress
 import logging
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor
 from itertools import zip_longest
 
@@ -96,3 +98,33 @@ def is_valid_id(value):
         return True
     except:
         return False
+
+
+#
+# URL validations, port from the same validations applied by Portal
+#
+
+URL_REGEX = re.compile(
+  r"^(?!.*strings\.domain:[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*(\.[a-z]{2,})(\/\w+)?$)"
+  r"(https?:\/\/)?[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*(\.[a-z]{2,})(\/\w+)?")
+
+
+DOMAIN_REGEX = re.compile(
+  r"^(?!:\/\/)(?!-)(?!\d+(\.\d+){3})(?:[a-zA-Z0-9-]{1,63}|xn--[\w-]{1,59})(?<!-)"
+  r"(?:\.(?:[a-zA-Z0-9-]{1,63}|xn--[\w-]{1,59}))+\.?$")
+
+
+def is_ip(value):
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
+
+
+def is_domain(value):
+    return bool(DOMAIN_REGEX.match(value))
+
+
+def is_url(value):
+    return bool(URL_REGEX.match(value)) or is_domain(value) or is_ip(value)

--- a/src/polyswarm/utils.py
+++ b/src/polyswarm/utils.py
@@ -100,15 +100,7 @@ def is_valid_id(value):
         return False
 
 
-#
-# URL validations, port from the same validations applied by Portal
-#
-
-URL_REGEX = re.compile(
-  r"^(?!.*strings\.domain:[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*(\.[a-z]{2,})(\/\w+)?$)"
-  r"(https?:\/\/)?[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*(\.[a-z]{2,})(\/\w+)?")
-
-
+# Domain regex validation, port from UI
 DOMAIN_REGEX = re.compile(
   r"^(?!:\/\/)(?!-)(?!\d+(\.\d+){3})(?:[a-zA-Z0-9-]{1,63}|xn--[\w-]{1,59})(?<!-)"
   r"(?:\.(?:[a-zA-Z0-9-]{1,63}|xn--[\w-]{1,59}))+\.?$")
@@ -127,4 +119,6 @@ def is_domain(value):
 
 
 def is_url(value):
-    return bool(URL_REGEX.match(value)) or is_domain(value) or is_ip(value)
+    return value.startswith("https://") or value.startswith("http://") \
+        or is_domain(value) \
+        or is_ip(value)


### PR DESCRIPTION
Prevent the user to provide wrong URLs, specially when by mistake they try to provide in the URL argument a path file to the TXT with the actual URLs, or a QR Code image path, both provided with special arguments (not positional).

Note: no need for bumping, a un-released version is on develop yet.