### PR TITLE
Fix NPE when sandbox doesn't have config object

### DIFF
--- a/src/polyswarm/formatters/text.py
+++ b/src/polyswarm/formatters/text.py
@@ -351,7 +351,7 @@ class TextOutput(base.BaseOutput):
         output.append(self._white('============================= Sandbox Task ============================='))
         output.append(self._blue(f'ID: {task.id}'))
         output.append(self._blue(f'SHA256: {task.sha256}'))
-        artifact_type = task.config.get("artifact_type", 'FILE')
+        artifact_type = task.config.get("artifact_type", 'FILE') if task.config else 'FILE'
         output.append(self._white(f'Type: {artifact_type}'))
         if artifact_type == 'URL':
             output.append(self._white(f'URL: {task.artifact["filename"]}'))


### PR DESCRIPTION
There are some strange cases where the sandboxing instance may not have a `config` object, causing a NPE error that is fixed here. E.g. `sandbox lookup-id 90356991597343314`.