### PR TITLE
Update API to 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license='MIT',
     python_requires='>=3.7,<4',
     install_requires=[
-        'polyswarm-api~=3.11.0.dev0',
+        'polyswarm-api~=3.11',
         'click~=7.1',
         'colorama~=0.4.6',
         'click-log~=0.4.0',


### PR DESCRIPTION
Is not going to pass CI until https://github.com/polyswarm/polyswarm-api/pull/250 is merged and the new version of the API released.