### PR TITLE
chore: add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _templates
 e2e.yaml
 docker-compose.yaml
 .envrc
+.venv


### PR DESCRIPTION
## TL;DR

- Add `.venv` to `.gitignore` to prevent local virtual environments from being committed