### PR TITLE
Add `sandbox hash` subcommand to resandbox by sha256/sha1/md5

### DIFF
--- a/src/polyswarm/client/sandbox.py
+++ b/src/polyswarm/client/sandbox.py
@@ -32,6 +32,35 @@ def submit(ctx, provider_slug, artifact_id, vm_slug, internet_disabled):
         output.sandbox_task(tasks)
 
 
+@sandbox.command('hash', short_help='Submit by hash (sha256/sha1/md5) to be sandboxed.')
+@click.argument('provider_slug', type=click.STRING)
+@click.argument('hash_value', nargs=-1, required=True)
+@click.option('-r', '--hash-file', help='File of hashes, one per line.', type=click.File('r'))
+@click.option('--hash-type', help='Hash type [default:autodetect, sha256|sha1|md5].', default=None)
+@click.option('--vm_slug', 'vm_slug', type=click.STRING)
+@click.option('--internet-disabled', 'internet_disabled', type=click.BOOL, is_flag=True, default=False)
+@click.pass_context
+def hash_(ctx, provider_slug, hash_value, hash_file, hash_type, vm_slug, internet_disabled):
+    """
+    Submit a sample to the sandbox by hash. Resolves the hash to its latest
+    known artifact instance and sandboxes that instance.
+    """
+    api = ctx.obj['api']
+    output = ctx.obj['output']
+    hashes = utils.parse_hashes(hash_value, hash_file=hash_file)
+
+    instance_ids = []
+    for h in hashes:
+        instance = next(iter(api.search_hashes([h], hash_type=hash_type)), None)
+        if instance is None:
+            raise click.ClickException(f'No artifact instances found for hash {h}')
+        instance_ids.append(instance.id)
+
+    for task in api.sandbox_instances(
+            instance_ids, provider_slug=provider_slug, vm_slug=vm_slug, network_enabled=not internet_disabled):
+        output.sandbox_task(task)
+
+
 @sandbox.command('file', short_help='Submit a local file to be sandboxed.')
 @click.argument('provider', type=click.STRING)
 @click.argument('path', type=click.Path(exists=True), required=True)


### PR DESCRIPTION
## Summary

- Adds `polyswarm sandbox hash <provider> <sha256|sha1|md5>` so a known sample can be resandboxed by hash without first running `search hash` to pull out an artifact-instance id.
- Looks up the latest matching `ArtifactInstance` via `api.search_hashes` (`next(iter(...))` so we don't drain the full list), then forwards that instance id to the existing `api.sandbox_instances` path.
- Mirrors `sandbox instance`'s flag surface (`--vm_slug`, `--internet-disabled`) and accepts `-r/--hash-file` / `--hash-type` like `search hash`.
- If the hash has no known instances, fails with a clear `ClickException`.

## Motivation

The sandbox-submission surface is confusing: `sandbox instance` expects an artifact-instance id (`ArtifactInstance.id`), but the CLI argument is named `artifact-id`, `Polyswarm.sandbox(...)` takes `instance_id`, and the request body sends the value as `artifact_id`. cc @sbneto — same value, three names depending on where you stand; worth reconciling on the API/server side too.

## Test plan

- [ ] `polyswarm sandbox hash --help` renders.
- [ ] `polyswarm sandbox hash <provider> <known-sha256>` submits and returns a sandbox task.
- [ ] Unknown hash fails with `No artifact instances found for hash …`.
- [ ] Multiple positional hashes and `-r file` both work.
- [ ] `--internet-disabled` and `--vm_slug` are forwarded.
- [ ] Add a VCR-backed test in `tests/cli_test.py::SandoxTest`.