### PR TITLE
DN-8130: show md5 and sha1 in hunt result output

### DIFF
--- a/src/polyswarm/formatters/hashes.py
+++ b/src/polyswarm/formatters/hashes.py
@@ -45,6 +45,18 @@ class SHA1Output(base.BaseOutput):
     def artifact_instance(self, result, timeout=False):
         click.echo(result.sha1, file=self.out)
 
+    def historical_result(self, result):
+        if result.sha1:
+            click.echo(result.sha1, file=self.out)
+        else:
+            logger.warning('Could not render historical result as sha1, value is %s', result.sha1)
+
+    def live_result(self, result):
+        if result.sha1:
+            click.echo(result.sha1, file=self.out)
+        else:
+            logger.warning('Could not render live result as sha1, value is %s', result.sha1)
+
     def metadata(self, result):
         if result.sha1:
             click.echo(result.sha1, file=self.out)
@@ -61,6 +73,18 @@ class MD5Output(base.BaseOutput):
 
     def artifact_instance(self, result, timeout=False):
         click.echo(result.md5, file=self.out)
+
+    def historical_result(self, result):
+        if result.md5:
+            click.echo(result.md5, file=self.out)
+        else:
+            logger.warning('Could not render historical result as md5, value is %s', result.md5)
+
+    def live_result(self, result):
+        if result.md5:
+            click.echo(result.md5, file=self.out)
+        else:
+            logger.warning('Could not render live result as md5, value is %s', result.md5)
 
     def metadata(self, result):
         if result.md5:

--- a/src/polyswarm/formatters/text.py
+++ b/src/polyswarm/formatters/text.py
@@ -174,6 +174,10 @@ class TextOutput(base.BaseOutput):
         output.append(self._blue(f'Instance Id: {result.instance_id}'))
         output.append(self._white(f'Created at: {result.created}'))
         output.append(self._white(f'SHA256: {result.sha256}'))
+        if result.sha1:
+            output.append(self._white(f'SHA1: {result.sha1}'))
+        if result.md5:
+            output.append(self._white(f'MD5: {result.md5}'))
         output.append(self._white(f'Rule: {result.rule_name}'))
         if result.malware_family:
             output.append(self._red(f'Malware Family: {result.malware_family}'))
@@ -201,6 +205,10 @@ class TextOutput(base.BaseOutput):
         output.append(self._blue(f'Instance Id: {result.instance_id}'))
         output.append(self._white(f'Created at: {result.created}'))
         output.append(self._white(f'SHA256: {result.sha256}'))
+        if result.sha1:
+            output.append(self._white(f'SHA1: {result.sha1}'))
+        if result.md5:
+            output.append(self._white(f'MD5: {result.md5}'))
         output.append(self._white(f'Rule: {result.rule_name}'))
         if result.malware_family:
             output.append(self._red(f'Malware Family: {result.malware_family}'))


### PR DESCRIPTION
## TL;DR

- Text formatter: SHA1 and MD5 lines added under SHA256 for both `live_result` and `historical_result`. Only rendered when the field is present, so older API responses or URL artifacts (null md5/sha1) don't print bare \`SHA1: None\` rows.
- Hash formatters: \`SHA1Output\` and \`MD5Output\` gain \`historical_result\` / \`live_result\` methods (mirroring \`SHA256Output\`), so \`--output-format sha1\` / \`md5\` work uniformly across hunt results and artifact instances.
- JSON / PrettyJSON formatters: no code change needed — they emit \`result.json\` raw, so md5/sha1 surface automatically once polyswarm-api parses them.

Ticket: [DN-8130](https://polyswarm.atlassian.net/browse/DN-8130).

## Requires

- polyswarm-api PR [polyswarm/polyswarm-api#292](https://github.com/polyswarm/polyswarm-api/pull/292) — adds the \`md5\` / \`sha1\` attributes on \`LiveHuntResult\` and \`HistoricalHuntResult\`.
- artifact-index PR [polyswarm/artifact-index#1865](https://github.com/polyswarm/artifact-index/pull/1865) — server-side change that surfaces the fields.

All three PRs are forward-compatible at each layer: against older artifact-index, md5/sha1 stay null and the CLI skips the lines.

## Test plan

- [ ] \`pytest tests/\` passes locally (59/59 pass against existing cassettes)
- [ ] Against an artifact-index deployment carrying #1865 and polyswarm-api #292, \`polyswarm live result <id>\` and \`polyswarm historical result <id>\` show SHA1 / MD5 lines in text mode and the keys in JSON mode
- [ ] \`polyswarm --output-format sha1 live result <id>\` and \`--output-format md5 live result <id>\` print just the hash
- [ ] Older deployments without md5/sha1: the text output omits the lines, JSON output is unchanged shape

[DN-8130]: https://polyswarm.atlassian.net/browse/DN-8130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ