### PR TITLE
Metadata field properties CLI — develop-targeted resubmit + gitflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md — polyswarm-cli
+
+Orientation document for AI agents and humans new to the repo. Update it when major workflow decisions land.
+
+## Gitflow — **read this before opening a PR**
+
+This repo follows a strict `feature → develop → master` flow:
+
+```
+feature/*  ─┐
+            └─► develop  ─►  master
+```
+
+**Rules:**
+
+- **Feature PRs target `develop`**, never `master`. Branch off `develop`, push, open a PR with `develop` as the base. CI runs on the PR. Reviewers merge to `develop`.
+- **`develop → master` PRs are how `master` advances.** They're opened by a maintainer when a release-worthy batch of work is on `develop`. Most contributors never open one of these.
+- **Direct PRs to `master`** are wrong. If you opened one, close it, branch off `develop` instead, and re-open against `develop`.
+- **PyPI release happens automatically** when `pyproject.toml`'s `version` changes on `master`. Don't bump the version inside a feature PR unless the maintainer specifically asks — version bumps belong to the `develop → master` step.
+
+**Why this matters:** `master` is the published surface of the CLI. PyPI consumers see whatever shows up there. Skipping `develop` skips the integration soak that protects against accidentally shipping a half-baked change.
+
+### Checking the base before pushing
+
+Before pushing a feature branch, sanity-check what `gh pr create` will target:
+
+```bash
+gh pr create --base develop --head <your-branch> --title "<…>" --body "<…>"
+```
+
+If you ever omit `--base`, the gh CLI defaults to the repo's default branch — which on this repo is `develop`, but it's worth being explicit.
+
+### Past incident
+
+PR #242 was merged directly to `master` and had to be reverted (#243) and re-opened against `develop`. The version file wasn't touched, so no PyPI release fired — but the rollback was still disruptive. Don't repeat it.
+
+## Layout
+
+- `src/polyswarm/polyswarm.py` — the top-level click app definition.
+- `src/polyswarm/client/` — one module per command group (`search.py`, `report.py`, `engine.py`, …). Each registers its click commands against a `@click.group` and is wired into the top-level app in `polyswarm.py`.
+- `src/polyswarm/formatters/` — output renderers: `text.py`, `json.py`, `hashes.py`, `base.py`. Each command's output goes through one of these; add a method per new resource type.
+- `tests/` — `CliRunner` tests with SDK methods mocked at the boundary; no live polyswarm stack needed.
+
+## When adding a new resource family of commands
+
+Mirror the existing patterns (e.g. `field-property`, `prompt-config`, `ruleset`):
+
+1. **SDK first.** The `polyswarm-api` repo ships the convenience methods (`api.foobar_write`, `api.foobar_get`, …). The CLI just wraps them.
+2. **Group, then subcommands.** For a multi-verb resource, declare `@<parent>.group('resource-name')` (e.g. `@search.group('field-property')`), then attach the verbs (`write`, `get`, `delete`, `list`) to that group. Keeps the command tree shallow and readable.
+3. **Formatters.** Add a method named after the resource on both `JSONOutput` (`formatters/json.py`) and `TextOutput` (`formatters/text.py`). Text output should match the style of the existing labelled blocks (`llm_prompt_config`, `webhook`, etc.).
+4. **Tests.** Use `click.testing.CliRunner` and `mock.patch('polyswarm_api.api.PolyswarmAPI.foobar_*')` to mock at the SDK boundary. No live stack, no VCR.
+
+## Companion repos
+
+- `polyswarm-api` — the SDK these commands wrap. SDK changes that need a CLI surface usually ship as a pair (`polyswarm-api` PR + `polyswarm-cli` PR with the SDK PR linked under `## Requires`).
+- `artifact-index` — the server-side API the SDK talks to. New endpoints land there first; the SDK PR comes after; the CLI PR comes last.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/polyswarm/client/search.py
+++ b/src/polyswarm/client/search.py
@@ -168,6 +168,77 @@ def mapping(ctx):
     output.mapping(api.metadata_mapping())
 
 
+@search.command('field-property-create', short_help='Create a metadata field property entry.')
+@click.argument('field_path', type=click.STRING)
+@click.option('--description', required=True, type=click.STRING, help='Human-readable description of the field.')
+@click.option('--example', type=click.STRING, help='Optional example search string.')
+@click.option('--category', type=click.STRING, help='Optional category grouping the field belongs to.')
+@click.option('--alias', 'aliases', type=click.STRING, multiple=True,
+              help='Friendly-name alias for this field (may be passed multiple times).')
+@click.pass_context
+def field_property_create(ctx, field_path, description, example, category, aliases):
+    api = ctx.obj['api']
+    output = ctx.obj['output']
+    result = api.metadata_field_properties_create(
+        field_path=field_path,
+        description=description,
+        example=example,
+        category=category,
+        aliases=list(aliases) if aliases else None,
+    )
+    output.metadata_field_properties(result)
+
+
+@search.command('field-property-get', short_help='Fetch a metadata field property entry by field_path.')
+@click.argument('field_path', type=click.STRING)
+@click.pass_context
+def field_property_get(ctx, field_path):
+    api = ctx.obj['api']
+    output = ctx.obj['output']
+    result = api.metadata_field_properties_get(field_path=field_path)
+    output.metadata_field_properties(result)
+
+
+@search.command('field-property-update', short_help='Update a metadata field property entry.')
+@click.argument('field_path', type=click.STRING)
+@click.option('--description', type=click.STRING, help='New description.')
+@click.option('--example', type=click.STRING, help='New example.')
+@click.option('--category', type=click.STRING, help='New category.')
+@click.option('--alias', 'aliases', type=click.STRING, multiple=True,
+              help='Replacement alias list (passed multiple times). Pass none to leave aliases unchanged.')
+@click.pass_context
+def field_property_update(ctx, field_path, description, example, category, aliases):
+    api = ctx.obj['api']
+    output = ctx.obj['output']
+    result = api.metadata_field_properties_update(
+        field_path=field_path,
+        description=description,
+        example=example,
+        category=category,
+        aliases=list(aliases) if aliases else None,
+    )
+    output.metadata_field_properties(result)
+
+
+@search.command('field-property-delete', short_help='Delete a metadata field property entry.')
+@click.argument('field_path', type=click.STRING)
+@click.pass_context
+def field_property_delete(ctx, field_path):
+    api = ctx.obj['api']
+    output = ctx.obj['output']
+    result = api.metadata_field_properties_delete(field_path=field_path)
+    output.metadata_field_properties(result)
+
+
+@search.command('field-property-list', short_help='List all metadata field property entries.')
+@click.pass_context
+def field_property_list(ctx):
+    api = ctx.obj['api']
+    output = ctx.obj['output']
+    for result in api.metadata_field_properties_list():
+        output.metadata_field_properties(result)
+
+
 @search.command('scans', short_help='Search for all scans or a particular artifact.')
 @click.argument('hash_value', required=True)
 @click.pass_context

--- a/src/polyswarm/client/search.py
+++ b/src/polyswarm/client/search.py
@@ -168,7 +168,12 @@ def mapping(ctx):
     output.mapping(api.metadata_mapping())
 
 
-@search.command('field-property-create', short_help='Create a metadata field property entry.')
+@search.group('field-property', short_help='Manage metadata field property entries.')
+def field_property():
+    pass
+
+
+@field_property.command('create', short_help='Create a metadata field property entry.')
 @click.argument('field_path', type=click.STRING)
 @click.option('--description', required=True, type=click.STRING, help='Human-readable description of the field.')
 @click.option('--example', type=click.STRING, help='Optional example search string.')
@@ -189,7 +194,7 @@ def field_property_create(ctx, field_path, description, example, category, alias
     output.metadata_field_properties(result)
 
 
-@search.command('field-property-get', short_help='Fetch a metadata field property entry by field_path.')
+@field_property.command('get', short_help='Fetch a metadata field property entry by field_path.')
 @click.argument('field_path', type=click.STRING)
 @click.pass_context
 def field_property_get(ctx, field_path):
@@ -199,7 +204,7 @@ def field_property_get(ctx, field_path):
     output.metadata_field_properties(result)
 
 
-@search.command('field-property-update', short_help='Update a metadata field property entry.')
+@field_property.command('update', short_help='Update a metadata field property entry.')
 @click.argument('field_path', type=click.STRING)
 @click.option('--description', type=click.STRING, help='New description.')
 @click.option('--example', type=click.STRING, help='New example.')
@@ -220,7 +225,7 @@ def field_property_update(ctx, field_path, description, example, category, alias
     output.metadata_field_properties(result)
 
 
-@search.command('field-property-delete', short_help='Delete a metadata field property entry.')
+@field_property.command('delete', short_help='Delete a metadata field property entry.')
 @click.argument('field_path', type=click.STRING)
 @click.pass_context
 def field_property_delete(ctx, field_path):
@@ -230,7 +235,7 @@ def field_property_delete(ctx, field_path):
     output.metadata_field_properties(result)
 
 
-@search.command('field-property-list', short_help='List all metadata field property entries.')
+@field_property.command('list', short_help='List all metadata field property entries.')
 @click.pass_context
 def field_property_list(ctx):
     api = ctx.obj['api']

--- a/src/polyswarm/client/search.py
+++ b/src/polyswarm/client/search.py
@@ -173,7 +173,7 @@ def field_property():
     pass
 
 
-@field_property.command('create', short_help='Create a metadata field property entry.')
+@field_property.command('write', short_help='Upsert a metadata field property entry.')
 @click.argument('field_path', type=click.STRING)
 @click.option('--description', required=True, type=click.STRING, help='Human-readable description of the field.')
 @click.option('--example', type=click.STRING, help='Optional example search string.')
@@ -181,10 +181,12 @@ def field_property():
 @click.option('--alias', 'aliases', type=click.STRING, multiple=True,
               help='Friendly-name alias for this field (may be passed multiple times).')
 @click.pass_context
-def field_property_create(ctx, field_path, description, example, category, aliases):
+def field_property_write(ctx, field_path, description, example, category, aliases):
+    """Insert or update a metadata field property entry. The server upserts
+    by field_path — a missing entry is created, an existing one is updated."""
     api = ctx.obj['api']
     output = ctx.obj['output']
-    result = api.metadata_field_properties_create(
+    result = api.metadata_field_properties_write(
         field_path=field_path,
         description=description,
         example=example,
@@ -201,27 +203,6 @@ def field_property_get(ctx, field_path):
     api = ctx.obj['api']
     output = ctx.obj['output']
     result = api.metadata_field_properties_get(field_path=field_path)
-    output.metadata_field_properties(result)
-
-
-@field_property.command('update', short_help='Update a metadata field property entry.')
-@click.argument('field_path', type=click.STRING)
-@click.option('--description', type=click.STRING, help='New description.')
-@click.option('--example', type=click.STRING, help='New example.')
-@click.option('--category', type=click.STRING, help='New category.')
-@click.option('--alias', 'aliases', type=click.STRING, multiple=True,
-              help='Replacement alias list (passed multiple times). Pass none to leave aliases unchanged.')
-@click.pass_context
-def field_property_update(ctx, field_path, description, example, category, aliases):
-    api = ctx.obj['api']
-    output = ctx.obj['output']
-    result = api.metadata_field_properties_update(
-        field_path=field_path,
-        description=description,
-        example=example,
-        category=category,
-        aliases=list(aliases) if aliases else None,
-    )
     output.metadata_field_properties(result)
 
 

--- a/src/polyswarm/formatters/json.py
+++ b/src/polyswarm/formatters/json.py
@@ -166,6 +166,9 @@ class JSONOutput(base.BaseOutput):
     def llm_prompt_config(self, result, write=True):
         click.echo(self._to_json(result.json), file=self.out)
 
+    def metadata_field_properties(self, result, write=True):
+        click.echo(self._to_json(result.json), file=self.out)
+
     def llm_report_task(self, report, write=True):
         click.echo(self._to_json(report.json), file=self.out)
 

--- a/src/polyswarm/formatters/text.py
+++ b/src/polyswarm/formatters/text.py
@@ -690,6 +690,23 @@ class TextOutput(base.BaseOutput):
             output.append(self._white(f'Scan-Only Prompt: {config.scan_only_prompt}'))
         return self._output(output, write)
 
+    def metadata_field_properties(self, props, write=True):
+        output = []
+        output.append(self._white('========================= Metadata Field Properties ========================='))
+        output.append(self._blue(f'Field Path: {props.field_path}'))
+        output.append(self._white(f'Description: {props.description}'))
+        if props.example:
+            output.append(self._white(f'Example: {props.example}'))
+        if props.category:
+            output.append(self._white(f'Category: {props.category}'))
+        if props.aliases:
+            output.append(self._white(f'Aliases: {", ".join(props.aliases)}'))
+        if props.created:
+            output.append(self._white(f'Created: {props.created}'))
+        if props.updated:
+            output.append(self._white(f'Updated: {props.updated}'))
+        return self._output(output, write)
+
     def webhook(self, webhook, write=True):
         output = []
         output.append(self._white('============================= Webhook ============================='))

--- a/tests/field_property_test.py
+++ b/tests/field_property_test.py
@@ -53,7 +53,7 @@ class FieldPropertyCliTest(TestCase):
     def test_field_property_create(self):
         with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_create',
                         return_value=_fake_resource()) as m:
-            result = self._run('search', 'field-property-create',
+            result = self._run('search', 'field-property', 'create',
                                'polyunite.malware_family',
                                '--description', 'Identified malware family',
                                '--example', 'polyunite.malware_family:lockbit',
@@ -71,7 +71,7 @@ class FieldPropertyCliTest(TestCase):
     def test_field_property_create_with_aliases(self):
         with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_create',
                         return_value=_fake_resource(aliases=['family', 'malware'])) as m:
-            result = self._run('search', 'field-property-create',
+            result = self._run('search', 'field-property', 'create',
                                'polyunite.malware_family',
                                '--description', 'd',
                                '--alias', 'family',
@@ -83,7 +83,7 @@ class FieldPropertyCliTest(TestCase):
     def test_field_property_get(self):
         with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_get',
                         return_value=_fake_resource()) as m:
-            result = self._run('search', 'field-property-get',
+            result = self._run('search', 'field-property', 'get',
                                'polyunite.malware_family')
         assert result.exit_code == 0, result.output
         m.assert_called_once_with(field_path='polyunite.malware_family')
@@ -92,7 +92,7 @@ class FieldPropertyCliTest(TestCase):
     def test_field_property_update(self):
         with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_update',
                         return_value=_fake_resource(description='new desc')) as m:
-            result = self._run('search', 'field-property-update',
+            result = self._run('search', 'field-property', 'update',
                                'polyunite.malware_family',
                                '--description', 'new desc')
         assert result.exit_code == 0, result.output
@@ -107,7 +107,7 @@ class FieldPropertyCliTest(TestCase):
     def test_field_property_delete(self):
         with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_delete',
                         return_value=_fake_resource()) as m:
-            result = self._run('search', 'field-property-delete',
+            result = self._run('search', 'field-property', 'delete',
                                'polyunite.malware_family')
         assert result.exit_code == 0, result.output
         m.assert_called_once_with(field_path='polyunite.malware_family')
@@ -119,7 +119,7 @@ class FieldPropertyCliTest(TestCase):
         ]
         with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_list',
                         return_value=iter(rows)) as m:
-            result = self._run('search', 'field-property-list')
+            result = self._run('search', 'field-property', 'list')
         assert result.exit_code == 0, result.output
         m.assert_called_once_with()
         assert 'apkid.files.filename' in result.output

--- a/tests/field_property_test.py
+++ b/tests/field_property_test.py
@@ -1,0 +1,126 @@
+"""Tests for the metadata field-property CLI commands.
+
+These tests mock the SDK methods directly to keep the test runtime
+self-contained (no live artifact-index, no VCR cassettes).
+"""
+from unittest import TestCase, mock
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+from polyswarm.client import polyswarm as client
+
+
+_API_KEY = '1' * 32
+_API_URL = 'http://artifact-index-e2e:9696/v3'
+_COMMUNITY = 'gamma'
+
+
+def _fake_resource(field_path='polyunite.malware_family',
+                   description='Identified malware family',
+                   example='polyunite.malware_family:lockbit',
+                   category='polyunite',
+                   aliases=None):
+    obj = MagicMock()
+    obj.field_path = field_path
+    obj.description = description
+    obj.example = example
+    obj.category = category
+    obj.aliases = aliases
+    obj.created = '2026-05-20T00:00:00'
+    obj.updated = '2026-05-20T00:00:00'
+    obj.json = {
+        'field_path': field_path,
+        'description': description,
+        'example': example,
+        'category': category,
+        'aliases': aliases,
+    }
+    return obj
+
+
+class FieldPropertyCliTest(TestCase):
+    def setUp(self):
+        self.cli = CliRunner()
+
+    def _run(self, *cmd):
+        return self.cli.invoke(
+            client.polyswarm_cli,
+            ['-a', _API_KEY, '-u', _API_URL, '-c', _COMMUNITY] + list(cmd),
+            catch_exceptions=False,
+        )
+
+    def test_field_property_create(self):
+        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_create',
+                        return_value=_fake_resource()) as m:
+            result = self._run('search', 'field-property-create',
+                               'polyunite.malware_family',
+                               '--description', 'Identified malware family',
+                               '--example', 'polyunite.malware_family:lockbit',
+                               '--category', 'polyunite')
+        assert result.exit_code == 0, result.output
+        m.assert_called_once()
+        kwargs = m.call_args.kwargs
+        assert kwargs['field_path'] == 'polyunite.malware_family'
+        assert kwargs['description'] == 'Identified malware family'
+        assert kwargs['example'] == 'polyunite.malware_family:lockbit'
+        assert kwargs['category'] == 'polyunite'
+        assert kwargs['aliases'] is None
+        assert 'polyunite.malware_family' in result.output
+
+    def test_field_property_create_with_aliases(self):
+        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_create',
+                        return_value=_fake_resource(aliases=['family', 'malware'])) as m:
+            result = self._run('search', 'field-property-create',
+                               'polyunite.malware_family',
+                               '--description', 'd',
+                               '--alias', 'family',
+                               '--alias', 'malware')
+        assert result.exit_code == 0, result.output
+        kwargs = m.call_args.kwargs
+        assert kwargs['aliases'] == ['family', 'malware']
+
+    def test_field_property_get(self):
+        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_get',
+                        return_value=_fake_resource()) as m:
+            result = self._run('search', 'field-property-get',
+                               'polyunite.malware_family')
+        assert result.exit_code == 0, result.output
+        m.assert_called_once_with(field_path='polyunite.malware_family')
+        assert 'Identified malware family' in result.output
+
+    def test_field_property_update(self):
+        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_update',
+                        return_value=_fake_resource(description='new desc')) as m:
+            result = self._run('search', 'field-property-update',
+                               'polyunite.malware_family',
+                               '--description', 'new desc')
+        assert result.exit_code == 0, result.output
+        kwargs = m.call_args.kwargs
+        assert kwargs['field_path'] == 'polyunite.malware_family'
+        assert kwargs['description'] == 'new desc'
+        assert kwargs['example'] is None
+        assert kwargs['category'] is None
+        assert kwargs['aliases'] is None
+        assert 'new desc' in result.output
+
+    def test_field_property_delete(self):
+        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_delete',
+                        return_value=_fake_resource()) as m:
+            result = self._run('search', 'field-property-delete',
+                               'polyunite.malware_family')
+        assert result.exit_code == 0, result.output
+        m.assert_called_once_with(field_path='polyunite.malware_family')
+
+    def test_field_property_list(self):
+        rows = [
+            _fake_resource(field_path='apkid.files.filename', description='APK files'),
+            _fake_resource(field_path='artifact.id', description='Artifact ID'),
+        ]
+        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_list',
+                        return_value=iter(rows)) as m:
+            result = self._run('search', 'field-property-list')
+        assert result.exit_code == 0, result.output
+        m.assert_called_once_with()
+        assert 'apkid.files.filename' in result.output
+        assert 'artifact.id' in result.output

--- a/tests/field_property_test.py
+++ b/tests/field_property_test.py
@@ -50,10 +50,10 @@ class FieldPropertyCliTest(TestCase):
             catch_exceptions=False,
         )
 
-    def test_field_property_create(self):
-        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_create',
+    def test_field_property_write(self):
+        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_write',
                         return_value=_fake_resource()) as m:
-            result = self._run('search', 'field-property', 'create',
+            result = self._run('search', 'field-property', 'write',
                                'polyunite.malware_family',
                                '--description', 'Identified malware family',
                                '--example', 'polyunite.malware_family:lockbit',
@@ -68,10 +68,10 @@ class FieldPropertyCliTest(TestCase):
         assert kwargs['aliases'] is None
         assert 'polyunite.malware_family' in result.output
 
-    def test_field_property_create_with_aliases(self):
-        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_create',
+    def test_field_property_write_with_aliases(self):
+        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_write',
                         return_value=_fake_resource(aliases=['family', 'malware'])) as m:
-            result = self._run('search', 'field-property', 'create',
+            result = self._run('search', 'field-property', 'write',
                                'polyunite.malware_family',
                                '--description', 'd',
                                '--alias', 'family',
@@ -88,21 +88,6 @@ class FieldPropertyCliTest(TestCase):
         assert result.exit_code == 0, result.output
         m.assert_called_once_with(field_path='polyunite.malware_family')
         assert 'Identified malware family' in result.output
-
-    def test_field_property_update(self):
-        with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_update',
-                        return_value=_fake_resource(description='new desc')) as m:
-            result = self._run('search', 'field-property', 'update',
-                               'polyunite.malware_family',
-                               '--description', 'new desc')
-        assert result.exit_code == 0, result.output
-        kwargs = m.call_args.kwargs
-        assert kwargs['field_path'] == 'polyunite.malware_family'
-        assert kwargs['description'] == 'new desc'
-        assert kwargs['example'] is None
-        assert kwargs['category'] is None
-        assert kwargs['aliases'] is None
-        assert 'new desc' in result.output
 
     def test_field_property_delete(self):
         with mock.patch('polyswarm_api.api.PolyswarmAPI.metadata_field_properties_delete',


### PR DESCRIPTION
## TL;DR

Re-opening the metadata field properties CLI work against `develop` (was originally #242 to `master`, which has been reverted in #243 — that PR bypassed this repo's `feature → develop → master` gitflow).

Same CLI surface as the original PR — `polyswarm search field-property write|get|delete|list` wrapping the new SDK methods — plus a new `AGENTS.md` (with a `CLAUDE.md` symlink) documenting the gitflow so this kind of mistake doesn't recur.

Tracking: DN-8222.

## Commands

```text
polyswarm search field-property write <field_path>
        --description "<…>"
        [--example "<…>"] [--category "<…>"] [--alias … --alias …]
polyswarm search field-property get <field_path>
polyswarm search field-property delete <field_path>
polyswarm search field-property list
```

- `<field_path>` is the dotted Elasticsearch / OpenSearch leaf (e.g. `polyunite.malware_family`, `apkid.files.filename`) — same identifier the existing `polyswarm search mapping` output is keyed by.
- `write` is a single upsert path: it inserts if the entry doesn't exist, updates if it does.
- `list` paginates server-side; the CLI walks every page via the existing SDK list generator.
- All commands require an admin API key (`akm_admin` feature) — gated server-side.

## Changes

- `src/polyswarm/client/search.py` — new `field-property` click group under `search` with `write`/`get`/`delete`/`list` subcommands.
- `src/polyswarm/formatters/json.py` — `metadata_field_properties` JSON formatter.
- `src/polyswarm/formatters/text.py` — `metadata_field_properties` text formatter.
- `tests/field_property_test.py` — 5 `CliRunner` tests with the SDK methods mocked.
- **`AGENTS.md` + `CLAUDE.md`** — new orientation doc documenting the `feature → develop → master` flow so the #242 mistake doesn't recur.

## Tests

```
$ python -m pytest tests/field_property_test.py -v
============================== 5 passed in 0.09s ==============================
```

## Requires

- polyswarm-api PR https://github.com/polyswarm/polyswarm-api/pull/297 — SDK methods this CLI wraps.
- (transitively) artifact-index PR https://github.com/polyswarm/artifact-index/pull/1869 — endpoints the SDK calls.

## Note on the original PR / rollback

- **#242** — original PR, merged directly to `master`. Mistake. No PyPI release fired (version not bumped).
- **#243** — rollback PR, reverts #242 from `master`.
- **This PR** — same CLI diff plus `AGENTS.md`, targeting `develop` as it should have from the start.
