### PR TITLE
chore: add Claude Code Review workflow, specs/, and AGENTS.md restructure

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,80 @@
+name: Claude Code Review
+
+# Auto-review every PR on open + each subsequent push.
+# To pause without removing the file: set `if: false` on the job.
+#
+# Requires repo (or org) secret ANTHROPIC_API_KEY — pay-as-you-go via
+# Anthropic Console, separate from any individual's Claude.com subscription.
+# OAuth-token variant: swap `anthropic_api_key` for `claude_code_oauth_token`.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this PR against the project's CLAUDE.md / AGENTS.md
+            and the `specs/` directory — they are authoritative on
+            conventions, contracts, architecture, and intent. Read the
+            spec for every area the PR touches before reviewing the
+            corresponding code.
+
+            Focus on real issues, ordered by severity:
+              1. Correctness — bugs, error-handling gaps, request /
+                 response shape mismatches, transport-boundary
+                 problems, broken state machines.
+              2. Spec drift — does the change match `AGENTS.md` and
+                 the relevant `specs/*.md`? Flag code that contradicts
+                 a documented invariant, and flag specs that need
+                 updating because the code rightly moved past them.
+                 The architecture rules, file roles, and "where does a
+                 new endpoint go" decisions all live in those docs —
+                 quote them when measuring.
+              3. Downstream contract — changes to the public surface
+                 (exported classes, method signatures, response
+                 shapes, exception classes, monkey-patch sites listed
+                 in the specs) need an explicit version-bump
+                 decision. The bump policy is in AGENTS.md.
+              4. Test coverage — does the test exercise the new path?
+                 Cite specific missing cases. Test conventions (mock
+                 layers, cassette workflow, parametrised harness) are
+                 in `specs/04-testing.md`.
+              5. Gitflow — `AGENTS.md` documents the branch base and
+                 version-bump rules; flag any PR that violates them.
+
+            Skip:
+              - Style nits any auto-formatter already enforces.
+              - "Consider adding tests" suggestions with no specific
+                missing case.
+              - Architectural rewrites for hypothetical future
+                requirements.
+
+            Be terse. Comment only on issues that need action. If the
+            PR is clean against the documented conventions, say so in
+            one line and stop.
+
+            Post your review via `gh pr comment`.
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,31 @@
 
 Orientation document for AI agents and humans new to the repo. Update it when major workflow decisions land.
 
+This file points at the right places to read for context, lays out the gitflow / testing / commit conventions, and outlines the CLI's architecture. **Detailed contracts, invariants, and per-area design live under [`specs/`](./specs/)** — read those before changing the corresponding code.
+
+The `specs/` tree is **incremental**: it captures what the CLI has actually defined so far and is augmented as the tool grows. Several specs are seeds today. If a spec is thin or missing for an area you're changing, fill it in **in the same PR** as the code — don't let the code outrun the docs silently.
+
+## Reading order for a new contributor
+
+1. This file (gitflow + conventions + architectural shape).
+2. [`specs/00-overview.md`](./specs/00-overview.md) — what the CLI is and how the pieces fit.
+3. The spec(s) for the area you're changing — see the [`specs/`](./specs/) index below.
+4. The code in `src/polyswarm/` itself; the specs are authoritative on intent, the code on detail.
+
+## Specs index
+
+| Spec | Scope |
+|---|---|
+| [`specs/00-overview.md`](./specs/00-overview.md) | What this repo ships (the `polyswarm` CLI), where it sits in the platform, repo layout |
+| [`specs/01-architecture.md`](./specs/01-architecture.md) | The click app, the `Polyswarm(PolyswarmAPI)` wrapper, `client/` command modules, `formatters/`, `utils.py`, `exceptions.py`, the `ctx.obj` pattern |
+| [`specs/02-commands.md`](./specs/02-commands.md) | Command-group catalogue and the SDK methods each wraps *(incremental)* |
+| [`specs/03-formatters.md`](./specs/03-formatters.md) | Output rendering: `text`/`json`/`hashes`, the `BaseOutput` interface, exit codes *(incremental)* |
+| [`specs/04-testing.md`](./specs/04-testing.md) | `CliRunner` tests, SDK-boundary mocks, the VCR cassette workflow |
+| [`specs/05-sdk-contract.md`](./specs/05-sdk-contract.md) | The CLI's dependency on the `polyswarm-api` SDK surface; paired-PR convention; version coupling |
+| [`specs/99-open-questions.md`](./specs/99-open-questions.md) | Known follow-ups and unresolved questions |
+
+Specs follow a convention: each opens with **Scope** and **Invariants**, lists the files/symbols it covers, and is independently readable. Update the spec in the same PR as the code change; if a PR drifts from a spec, the spec is wrong until proven otherwise.
+
 ## Gitflow — **read this before opening a PR**
 
 This repo follows a strict `feature → develop → master` flow:
@@ -34,23 +59,49 @@ If you ever omit `--base`, the gh CLI defaults to the repo's default branch — 
 
 PR #242 was merged directly to `master` and had to be reverted (#243) and re-opened against `develop`. The version file wasn't touched, so no PyPI release fired — but the rollback was still disruptive. Don't repeat it.
 
-## Layout
+## Architectural shape (the short version)
 
-- `src/polyswarm/polyswarm.py` — the top-level click app definition.
-- `src/polyswarm/client/` — one module per command group (`search.py`, `report.py`, `engine.py`, …). Each registers its click commands against a `@click.group` and is wired into the top-level app in `polyswarm.py`.
-- `src/polyswarm/formatters/` — output renderers: `text.py`, `json.py`, `hashes.py`, `base.py`. Each command's output goes through one of these; add a method per new resource type.
-- `tests/` — `CliRunner` tests with SDK methods mocked at the boundary; no live polyswarm stack needed.
+Detailed treatment is in [`specs/01-architecture.md`](./specs/01-architecture.md). The summary:
 
-## When adding a new resource family of commands
+`polyswarm-cli` is a thin [`click`](https://click.palletsprojects.com/) front-end over the [`polyswarm-api`](https://github.com/polyswarm/polyswarm-api) SDK. It owns **presentation and orchestration**, not protocol — every HTTP call goes through the SDK.
+
+- **The app** — [`src/polyswarm/client/polyswarm.py`](./src/polyswarm/client/polyswarm.py) defines `polyswarm_cli`, the top-level `click.Group` (an `ExceptionHandlingGroup` that maps exceptions to exit codes). Each command-group module is `add_command`-ed onto it. Entry point: `polyswarm = polyswarm.__main__:polyswarm_cli`.
+- **The SDK wrapper** — [`src/polyswarm/polyswarm.py`](./src/polyswarm/polyswarm.py) defines `class Polyswarm(PolyswarmAPI)`. It subclasses the SDK client to add CLI-only conveniences: parallel fan-out over many hashes/ids (`search_hashes`, `download_multiple`, …), multi-step flows (`scan_file`, `submit_url`), and a `parallel` worker count. It reaches into SDK internals **only** through the documented public surface (see `specs/05-sdk-contract.md`).
+- **Command modules** — [`src/polyswarm/client/`](./src/polyswarm/client/), one module per command group (`search.py`, `report.py`, `sandbox.py`, …). Each declares a `@click.group` (or commands), pulls `api = ctx.obj['api']` / `output = ctx.obj['output']`, calls SDK methods, and renders via the output formatter.
+- **Formatters** — [`src/polyswarm/formatters/`](./src/polyswarm/formatters/): `text.py`, `json.py`, `hashes.py`, all implementing the `base.py` `BaseOutput` interface (one method per resource type). The `--output-format` option picks one.
+- **Support** — [`src/polyswarm/utils.py`](./src/polyswarm/utils.py) (parallel executors, hash/id parsing/validation) and [`src/polyswarm/exceptions.py`](./src/polyswarm/exceptions.py) (the CLI's own exception hierarchy, distinct from the SDK's).
+
+The `polyswarm_cli` group seeds `ctx.obj` with a constructed `Polyswarm` client (`api`) and a chosen formatter (`output`); every command reads those two from `ctx.obj`.
+
+## When adding a new command family
 
 Mirror the existing patterns (e.g. `field-property`, `prompt-config`, `ruleset`):
 
-1. **SDK first.** The `polyswarm-api` repo ships the convenience methods (`api.foobar_write`, `api.foobar_get`, …). The CLI just wraps them.
-2. **Group, then subcommands.** For a multi-verb resource, declare `@<parent>.group('resource-name')` (e.g. `@search.group('field-property')`), then attach the verbs (`write`, `get`, `delete`, `list`) to that group. Keeps the command tree shallow and readable.
+1. **SDK first.** The `polyswarm-api` repo ships the convenience methods (`api.foobar_write`, `api.foobar_get`, …). The CLI just wraps them. SDK changes that need a CLI surface ship as a pair — see `specs/05-sdk-contract.md`.
+2. **Group, then subcommands.** For a multi-verb resource, declare `@<parent>.group('resource-name')` (e.g. `@search.group('field-property')`), then attach the verbs (`write`, `get`, `delete`, `list`) to that group. Keeps the command tree shallow and readable. Wire the new group into `polyswarm_cli` in `client/polyswarm.py`.
 3. **Formatters.** Add a method named after the resource on both `JSONOutput` (`formatters/json.py`) and `TextOutput` (`formatters/text.py`). Text output should match the style of the existing labelled blocks (`llm_prompt_config`, `webhook`, etc.).
-4. **Tests.** Use `click.testing.CliRunner` and `mock.patch('polyswarm_api.api.PolyswarmAPI.foobar_*')` to mock at the SDK boundary. No live stack, no VCR.
+4. **Consume SDK generators correctly.** Paginated/search SDK methods return **generators** — iterate them (`for x in api.foo(): output.foo(x)`); never pass a generator to a singular formatter or call `len()`/index it. See `specs/05-sdk-contract.md`.
+5. **Tests.** Use `click.testing.CliRunner` and `mock.patch('polyswarm_api.api.PolyswarmAPI.foobar_*')` to mock at the SDK boundary. See `specs/04-testing.md`.
+6. **Update the specs** for the area you touched (at least `02-commands.md`) in the same PR.
 
-## Companion repos
+## Testing & VCR workflow
+
+Details in [`specs/04-testing.md`](./specs/04-testing.md). The shape:
+
+- Tests live in `tests/` and drive the CLI through `click.testing.CliRunner` — no live PolySwarm stack needed.
+- Two styles: **SDK-boundary mocks** (`mock.patch('polyswarm_api.api.PolyswarmAPI.<method>')`, e.g. `tests/field_property_test.py`) and **VCR cassettes** (`tests/cli_test.py`) that replay recorded HTTP for end-to-end CLI runs. Cassettes live in `tests/vcr/` (`.vcr` for the HTTP interactions, `.click` for the expected rendered output).
+- VCR is an **efficiency cache, not a requirement** — the suite must pass against a live e2e stack with VCR off. Re-record a cassette by deleting it and re-running the test against a live stack; never hand-edit a cassette or `cp` one from a sibling test.
+
+## Commit + PR hygiene
+
+- Conventional commit prefixes (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`).
+- Small, scoped commits — each one should be independently reviewable.
+- **Don't reference ticket IDs or internal project codes in commit messages, PR titles, or PR descriptions.** This repo is public; published artefacts shouldn't leak internal references. Track tickets in the internal tracker, not the git history.
+- **Don't name private companion repos in PR descriptions or commit messages on this repo.** Refer to internal services by category, not by repo name.
+- No AI-attribution trailers on commits (`Co-Authored-By: Claude …`, "Generated with Claude Code", etc.) — they're noise and they don't belong in project history.
+- PRs that depend on an unreleased `polyswarm-api` surface must link the SDK PR under a `## Requires` section (see `specs/05-sdk-contract.md`).
+
+## Companion repos (public)
 
 - `polyswarm-api` — the SDK these commands wrap. SDK changes that need a CLI surface usually ship as a pair (`polyswarm-api` PR + `polyswarm-cli` PR with the SDK PR linked under `## Requires`).
 - `artifact-index` — the server-side API the SDK talks to. New endpoints land there first; the SDK PR comes after; the CLI PR comes last.

--- a/specs/00-overview.md
+++ b/specs/00-overview.md
@@ -1,0 +1,81 @@
+# polyswarm-cli — Overview
+
+## Scope
+
+What the `polyswarm` CLI is, what it ships, where it sits in the platform, and how the repository is laid out. Subsequent specs zoom in on a single area; this one is the map.
+
+## Invariants
+
+- **The CLI is a client of the SDK.** It performs no HTTP itself — every network call goes through the [`polyswarm-api`](https://github.com/polyswarm/polyswarm-api) SDK (`PolyswarmAPI`). Protocol concerns (request/response shapes, auth, retries, pagination, transport) live in the SDK, not here.
+- **The product is the CLI, not a library.** The published surface is the `polyswarm` console script and its command tree. The `polyswarm` Python package is importable but isn't a supported API for third parties.
+- **`master` is the release branch.** A version bump on `master` triggers a PyPI release. Feature PRs always target `develop` (see `AGENTS.md` §Gitflow).
+- **Presentation + orchestration only.** The CLI's job is parsing arguments, fanning work out in parallel, calling SDK methods, and rendering results in the chosen format. Business logic and the wire contract belong to the SDK and the server.
+
+## What this repo ships
+
+| Artefact | Description |
+|---|---|
+| `polyswarm` console script | The CLI. Entry point `polyswarm.__main__:polyswarm_cli` (declared in `pyproject.toml` `[project.scripts]`). |
+| `polyswarm` Python package | `src/polyswarm/` — the click app, the SDK wrapper, command modules, formatters, helpers. Importable, but the CLI is the product. |
+
+## Where it sits
+
+```
+   ┌─────────────────────┐
+   │   end user / CI     │   `polyswarm search hash …`, `polyswarm report create …`
+   └──────────┬──────────┘
+              │ argv
+              ▼
+   ┌─────────────────────┐
+   │  polyswarm-cli (this)│  click commands → SDK calls → formatted output.
+   │  polyswarm_cli group │  Presentation + orchestration (parallel fan-out).
+   └──────────┬──────────┘
+              │ PolyswarmAPI (sync)
+              ▼
+   ┌─────────────────────┐
+   │   polyswarm-api      │  The SDK. Owns HTTP, auth, retries, pagination,
+   │   PolyswarmAPI       │  request/response parsing.
+   └──────────┬──────────┘
+              │ httpx
+              ▼
+   ┌─────────────────────┐
+   │   artifact-index     │  The server-side REST API.
+   └─────────────────────┘
+```
+
+A change that needs a new server capability lands in `artifact-index` first, then `polyswarm-api` (SDK method + resource), then `polyswarm-cli` (the command that wraps it). See [`05-sdk-contract.md`](./05-sdk-contract.md).
+
+## Repo layout
+
+```
+src/polyswarm/
+├── __main__.py            ← console-script entry; calls polyswarm_cli(prog_name=…, obj={})
+├── polyswarm.py           ← class Polyswarm(PolyswarmAPI): the SDK wrapper subclass
+│                            (parallel fan-out + multi-step flows)
+├── client/                ← one module per command group, plus the app definition
+│   ├── polyswarm.py        ← polyswarm_cli (top-level group, ExceptionHandlingGroup),
+│   │                         global options, ctx.obj seeding, add_command wiring
+│   ├── search.py / report.py / sandbox.py / engine.py / live.py / historical.py /
+│   │   download.py / metadata.py / tags.py / links.py / families.py / rules.py /
+│   │   report_template.py / notification_webhook.py / notification.py / account.py /
+│   │   event.py / bundle.py / sample.py / scan.py
+│   └── utils.py            ← click-facing helpers (validate_key, validate_id, parse_hashes,
+│                             any_provided decorator)
+├── formatters/            ← output renderers
+│   ├── base.py             ← BaseOutput (the interface; one method per resource type)
+│   ├── text.py / json.py / hashes.py
+│   └── __init__.py         ← `formatters` registry keyed by --output-format
+├── utils.py               ← parallel executors + hash/IP/id parsing & validation
+└── exceptions.py          ← CLI-side exception hierarchy (distinct from the SDK's)
+
+specs/                     ← this directory (incremental; see AGENTS.md)
+tests/                     ← CliRunner tests + VCR cassettes (tests/vcr/*.{vcr,click})
+.github/workflows/         ← claude-code-review.yml (PR auto-review)
+.gitlab-ci.yml             ← test (py310/311/312) + dev/release PyPI
+```
+
+## Version & release
+
+- The CLI's own version lives in `pyproject.toml` `version` + `[tool.bumpversion]`, mirrored into `src/polyswarm/__init__.py`. It is **independent of the SDK version**.
+- Don't bump it in a feature PR — version bumps belong to the `develop → master` release step (`AGENTS.md` §Gitflow). A version change on `master` fires the PyPI release.
+- The dependency on the SDK is a pin in `pyproject.toml` (`polyswarm_api>=…`); see [`05-sdk-contract.md`](./05-sdk-contract.md) for the coupling rules.

--- a/specs/01-architecture.md
+++ b/specs/01-architecture.md
@@ -1,0 +1,83 @@
+# polyswarm-cli — Architecture
+
+## Scope
+
+The components of the CLI and how a command flows from `argv` to rendered output: the click app, the `Polyswarm(PolyswarmAPI)` wrapper, the command modules, the formatters, the parallel-execution helpers, and the exception → exit-code mapping. Files: `src/polyswarm/client/polyswarm.py`, `src/polyswarm/polyswarm.py`, `src/polyswarm/client/*.py`, `src/polyswarm/formatters/*.py`, `src/polyswarm/utils.py`, `src/polyswarm/exceptions.py`.
+
+## Invariants
+
+- **No HTTP in the CLI.** Commands call SDK methods; the SDK owns the wire. The CLI never constructs an `httpx`/`requests` call directly.
+- **Commands read `api` and `output` from `ctx.obj`.** The top-level group seeds them once; commands don't construct their own client or formatter.
+- **One command-group module per resource family**, wired into `polyswarm_cli` via `add_command`. A module owns its `@click.group`, its subcommands, and nothing else.
+- **Rendering goes through a formatter method**, never `print`/`click.echo` of an SDK object directly. Every renderable resource type has a method on `BaseOutput` and an implementation in each concrete formatter.
+- **Exit codes are assigned centrally** by `ExceptionHandlingGroup`, by exception type — commands raise (or let SDK exceptions propagate), they don't call `sys.exit`.
+
+## The app — `client/polyswarm.py`
+
+`polyswarm_cli` is the top-level `click.Group`, constructed with `cls=ExceptionHandlingGroup`. It:
+
+1. Declares the **global options** — `--api-key` (env `POLYSWARM_API_KEY`), `--api-uri` (env `POLYSWARM_API_URI`), `--output-file`, `--output-format`/`--fmt` (`text`|`json`|…), `--color/--no-color`, `--verbose`, `--community` (env `POLYSWARM_COMMUNITY`), `--parallel`, `--verify/--no-verify`, plus `--version` / `--api-version`.
+2. **Seeds `ctx.obj`** — constructs a `Polyswarm(...)` client (the SDK wrapper) as `ctx.obj['api']` and the selected formatter as `ctx.obj['output']`.
+3. **Wires the command groups** — each `client/<family>.py` group/command is imported and `add_command`-ed onto `polyswarm_cli`.
+
+The console-script entry (`__main__.py`) calls `polyswarm_cli(prog_name='polyswarm', obj={})`.
+
+### `ExceptionHandlingGroup` — exit-code mapping
+
+`ExceptionHandlingGroup.invoke` wraps `super().invoke(ctx)` and maps exceptions to process exit codes (commands stay clean of `sys.exit`):
+
+| Exception (CLI `exceptions.*` and SDK `api_exceptions.*`) | Exit code |
+|---|---|
+| `NoResultsException`, `NotFoundException`, `FailedInstanceException` (SDK) | `1` |
+| `PartialResultsException` (CLI) | `3` |
+| `InternalFailureException`, `PolyswarmException`, `JSONDecodeError`, `UnicodeDecodeError` | `2` |
+| Transport errors matched by class name (`httpx` leaf names + legacy `requests` names) | `1` |
+| Any other `Exception` | `2` |
+
+The transport-error branch matches by `e.__class__.__name__` because those classes come from the SDK's HTTP dependency (`httpx`) and shouldn't be imported here directly.
+
+## The SDK wrapper — `polyswarm.py`
+
+`class Polyswarm(PolyswarmAPI)` subclasses the SDK's sync client to add **CLI-only** behaviour the SDK has no reason to ship:
+
+- **A `parallel` worker count** — popped from `kwargs` in `__init__` before `super().__init__`, used as `max_workers` for fan-out.
+- **Parallel fan-out** over many inputs — `search_hashes`, `search_urls`, `download_multiple`, `download_id_multiple`, `download_stream`, `sandbox_instances`, `tag_link_multiple`, `historical_results_multiple`, `historical_delete_multiple`, `scan_lookup`, etc. These drive `utils.parallel_executor*` over a per-item SDK call and yield results.
+- **Multi-step flows** — `scan_file` (submit + wait), `submit_url` (inline IP-analysis submit), the `*_and_wait` helpers.
+
+The wrapper only touches the SDK through its **documented public surface** (endpoint methods, `_single`, `session`, `resources`, `settings`); see [`05-sdk-contract.md`](./05-sdk-contract.md). Because the SDK's search/list methods are **generators**, the wrapper and its callers must iterate them — never index, `len()`, or hand a generator to a singular formatter.
+
+## Command modules — `client/*.py`
+
+One module per resource family. The shape of every command:
+
+```python
+@<group>.command('verb')
+@click.argument(...) / @click.option(...)
+@click.pass_context
+def verb(ctx, ...):
+    api = ctx.obj['api']
+    output = ctx.obj['output']
+    # single result:
+    output.<resource>(api.<method>(...))
+    # collection (SDK returns a generator):
+    for item in api.<method>(...):
+        output.<resource>(item)
+```
+
+The catalogue of groups and the SDK methods each wraps is in [`02-commands.md`](./02-commands.md).
+
+## Formatters — `formatters/`
+
+`BaseOutput` (`base.py`) is the interface: one method per renderable resource type (`artifact_instance`, `historical_result`, `hunt`, `local_artifact`, `ruleset`, `ioc`, `known_host`, `metadata`, `tag_link`, `family`, `tag`, `sandbox_task`, `bundle_task`, `sample`, …), each raising `NotImplementedError`. Concrete renderers — `TextOutput` (`text.py`), `JSONOutput` (`json.py`), and the hash-only `SHA256Output`/`SHA1Output`/`MD5Output` (`hashes.py`) — override them. `--output-format` selects one via the `formatters` registry (`formatters/__init__.py`). Details in [`03-formatters.md`](./03-formatters.md).
+
+## Support — `utils.py`, `exceptions.py`
+
+- **`utils.py`** — `parallelize`/`parallel_executor` (thread-pool fan-out with per-item exception aggregation: collects results, logs per-item no-results, raises an aggregate `NoResultsException`/`NotFoundException`/`InternalFailureException` at the end), `parallel_executor_iterable_results` (the same, for SDK methods that return generators — it materialises each generator inside the worker so per-item exception handling still fires), and input parsing/validation (`parse_hashes`, hash/IP detection).
+- **`exceptions.py`** — the CLI's own hierarchy, **distinct from the SDK's**: `PolyswarmException` → `NoResultsException`, `NotFoundException`, `InternalFailureException`, `PartialResultsException`. `ExceptionHandlingGroup` catches both these and the SDK's `api_exceptions.*`.
+
+## Lifecycle of a command (end to end)
+
+1. `polyswarm_cli` parses global options, builds `Polyswarm(api_key, uri=…, community=…, parallel=…, verify=…)` and the formatter into `ctx.obj`.
+2. The subcommand reads `api`/`output` from `ctx.obj`, parses its own args, and calls one or more SDK methods (directly or via a wrapper fan-out method).
+3. Results are rendered through the formatter; collections are iterated.
+4. Any exception propagates to `ExceptionHandlingGroup.invoke`, which logs it and raises `Exit(<code>)`.

--- a/specs/02-commands.md
+++ b/specs/02-commands.md
@@ -1,0 +1,42 @@
+# polyswarm-cli — Command catalogue
+
+## Scope
+
+The top-level command groups, what each is for, and the primary `polyswarm-api` SDK methods each wraps. Files: `src/polyswarm/client/*.py`, wired into `polyswarm_cli` in `src/polyswarm/client/polyswarm.py`.
+
+> **Incremental.** This is a catalogue seed: it maps each group to the SDK surface it sits on, which is what an automated reviewer needs to judge spec drift. Per-subcommand argument/option detail is intentionally **not** enumerated here yet — add a group's detail when you change it. Treat the code as authoritative on exact flags; treat this table as authoritative on "which group wraps which SDK area."
+
+## Invariants
+
+- **Every group is `add_command`-ed onto `polyswarm_cli`** in `client/polyswarm.py`. A new group isn't reachable until it's wired there.
+- **A command wraps SDK methods; it doesn't reimplement them.** If a command needs logic the SDK doesn't expose, the logic belongs in the SDK (or, for CLI-only orchestration like parallel fan-out, in the `Polyswarm` wrapper) — not inline in the command.
+- **Collection-returning SDK methods are generators** — commands iterate them (see [`05-sdk-contract.md`](./05-sdk-contract.md)).
+
+## Catalogue
+
+| Group / commands (module) | Purpose | Primary SDK methods wrapped |
+|---|---|---|
+| `search` (`search.py`) | Search by hash / URL / metadata / IOC / scans; metadata mapping; `field-property` subgroup | `search_hashes`, `search_urls`, `search_by_metadata`, `search_by_ioc`, `iocs_by_hash`, `search_scans`, `metadata_mapping`, `metadata_field_properties_{write,get,delete,list}` |
+| `known` + `search known` (`search.py`) | Manage / check known-good/-bad hosts | `add_known_good_host`, `add_known_bad_host`, `update_known_good_host`, `delete_known_good_host`, `check_known_hosts` |
+| `scan`, `lookup`, `wait`, `rescan`, `rescan-id` (`scan.py`) | Submit files/dirs and await results; look up / rescan existing scans | `scan_file`, `scan_lookup`, `wait_for`, `rescan`, `rescan_id` (wrapper methods over `submit`/`lookup`/`rescan`/`rescan_id`) |
+| `sandbox`, `sandbox-list` (`sandbox.py`) | Detonate artifacts/URLs in a sandbox; query sandbox tasks/providers | `sandbox_instances` (→ `sandbox`), `sandbox_file`, `sandbox_url`, `sandbox_providers`, `sandbox_task_status`, `sandbox_task_latest`, `sandbox_task_list`, `sandbox_my_tasks_list` |
+| `download`, `cat`, `stream`, `download-id`, `download-sandbox-artifact` (`download.py`) | Download artifacts by hash/id, stream the feed, fetch sandbox artifacts | `download_multiple`, `download_id_multiple`, `download_stream`, `download`, `download_id`, `download_archive`, `stream` |
+| `report` (`report.py`) | Create/fetch/download reports; `prompt-config` subgroup; LLM reports | `report_create`, `report_wait_for`, `report_download`, `report_get`, `llm_report_{create,get,download}`, `prompt_config_{create,get,update,list}` |
+| `report-template` (`report_template.py`) | Manage report templates + logos | `report_template_{create,update,get,list}`, `report_template_logo_{download,upload}` |
+| `engine` → `votes` / `assertions` (`engine.py`) | Consolidated votes/assertions bundles per engine | `votes_{create,get,delete,list}`, `assertions_{create,get,delete,list}` |
+| `live` (`live.py`) | Live YARA hunts: start/stop, feed, results | `live_start`, `live_stop`, `live_feed`, `live_result`, `live_feed_delete` |
+| `historical` (`historical.py`) | Historical hunts: CRUD + results | `historical_{get,create,update,list}`, `historical_delete_multiple`, `historical_delete_list`, `historical_results_multiple`, `historical_result`, `historical_results_delete` |
+| `tag` (`tags.py`) | Tag CRUD | `tag_{create,delete,get,list}` |
+| `link` (`links.py`) | Tag/family links on artifacts | `tag_link_multiple`, `tag_link_get`, `tag_link_list` |
+| `family` (`families.py`) | Malware-family CRUD | `family_{create,update,delete,get,list}` |
+| `rules` (`rules.py`) | YARA ruleset CRUD | `ruleset_{create,delete,update,get,list}` |
+| `metadata` (`metadata.py`) | Rerun metadata; scan lookup; IP/URL analysis | `rerun_metadata`, `scan_lookup`, `submit_url` |
+| `activity` (`event.py`) | List account activity/events | `event_list` |
+| `account` (`account.py`) | Account whois / features | `account_whois`, `account_features` |
+| `notification` / webhooks (`notification.py`, `notification_webhook.py`) | Notification webhook CRUD | `notification_webhook_{create,get,update,delete,list}` |
+| `bundle` (`bundle.py`) | Sample bundle tasks | `sample_bundle_task_create`, `sample_bundle_task_get`, `sample_bundle_download` |
+| `sample` (`sample.py`) | Fetch a consolidated sample view | `sample` |
+
+## Adding to the catalogue
+
+When you add or materially change a group, update its row (and add per-subcommand detail here if the behaviour is non-obvious). The `AGENTS.md` §"When adding a new command family" checklist covers the wiring + formatter + test steps.

--- a/specs/03-formatters.md
+++ b/specs/03-formatters.md
@@ -1,0 +1,40 @@
+# polyswarm-cli — Formatters
+
+## Scope
+
+How command output is rendered: the `BaseOutput` interface, the concrete formatters, how `--output-format` selects one, and the per-resource method convention. Files: `src/polyswarm/formatters/base.py`, `text.py`, `json.py`, `hashes.py`, `__init__.py`.
+
+> **Incremental.** The interface and selection mechanism below are stable and authoritative. The exact rendering rules for each resource (field layout, labels, colour) are intentionally **not** transcribed here yet — the concrete formatters are authoritative on that. Document a resource's rendering rules here when they become non-obvious or contested.
+
+## Invariants
+
+- **One method per renderable resource type**, declared on `BaseOutput` and implemented by every concrete formatter. Commands call `output.<resource>(obj)`; they never `print`/`click.echo` an SDK object directly.
+- **Adding a renderable resource means adding the method everywhere it's supported** — at minimum `TextOutput` and `JSONOutput`. A missing override inherits `BaseOutput`'s `NotImplementedError`, which surfaces as a bug, not silent omission.
+- **Formatters render; they don't fetch or decide flow.** No SDK calls, no business logic — they turn a resource (or an iterable of them) into text/JSON on the configured stream.
+
+## The interface — `base.py`
+
+`BaseOutput(output, **kwargs)` holds the output stream and exposes a method per resource type, each raising `NotImplementedError`. The set includes (non-exhaustive): `artifact_instance`, `historical_result`, `hunt`, `hunt_deletion`, `local_artifact`, `ruleset`, `ioc`, `iocs`, `known_host`, `metadata`, `artifact_metadata`, `tag_link`, `family`, `tag`, `sandbox_list`, `sandbox_task`, `sandbox_tasks`, `bundle_task`, `sample`. Concrete formatters add further methods as command families grow (e.g. `report_task`, `webhook`, `llm_prompt_config`, `metadata_field_properties`); keep `text` and `json` in sync.
+
+## Concrete formatters
+
+| Formatter | Module | Output |
+|---|---|---|
+| `TextOutput` | `text.py` | Human-readable, labelled blocks; honours `--color/--no-color`. Dates via `polyswarm_api.core.parse_isoformat`. |
+| `JSONOutput` | `json.py` | Machine-readable JSON (typically the resource's `.json` plus derived fields). |
+| `SHA256Output` / `SHA1Output` / `MD5Output` | `hashes.py` | Hash-only output — prints the relevant digest per result. |
+
+## Selecting a formatter
+
+`formatters/__init__.py` exposes a `formatters` registry keyed by the `--output-format` / `--fmt` value (`text`, `json`, …). `polyswarm_cli` looks up the chosen key, constructs the formatter against `--output-file` (default stdout), and stores it as `ctx.obj['output']`. Hash formatters are selected for hash-only commands as applicable.
+
+## Exit codes
+
+Formatters don't set exit codes — that's `ExceptionHandlingGroup`'s job, by exception type (see [`01-architecture.md`](./01-architecture.md) §exit-code mapping). A formatter rendering "no results" is distinct from the no-results **exit code**, which comes from the SDK/CLI `NoResultsException` path.
+
+## Adding a renderable resource
+
+1. Add `def <resource>(self, result, ...)` to `BaseOutput`.
+2. Implement it in `TextOutput` and `JSONOutput` (and the hash formatters if it carries hashes).
+3. Match the style of the existing labelled blocks for text output.
+4. Call it from the command (`output.<resource>(...)`), iterating if the SDK method returns a generator.

--- a/specs/04-testing.md
+++ b/specs/04-testing.md
@@ -1,0 +1,57 @@
+# polyswarm-cli — Testing
+
+## Scope
+
+How the CLI is tested: the `CliRunner` harness, the two mocking styles (SDK-boundary mocks vs VCR cassettes), the cassette layout and record workflow, and how to run the suite. Files: `tests/`, `tests/vcr/`, `src/conftest.py`, `pyproject.toml` (`[project.optional-dependencies].tests`, `[tool.pytest.ini_options]`).
+
+## Invariants
+
+- **Tests drive the CLI through `click.testing.CliRunner`** — they invoke the real command tree, not internal functions. No live PolySwarm stack is required.
+- **Mock at the SDK boundary, or replay HTTP with VCR — never both for the same path.** A test either patches `polyswarm_api.api.PolyswarmAPI.<method>` (unit-style) or lets VCR replay recorded HTTP (end-to-end). The CLI's own code is exercised either way.
+- **VCR is an efficiency cache, not a load-bearing requirement.** The suite must pass against a live e2e stack with VCR off. Don't hardcode `record_mode='none'`; if a test only works against its recorded cassette, that's a bug in the test.
+- **Never `cp` a cassette from a sibling test, never hand-edit cassette bytes.** Re-record against a live stack.
+
+## Running the suite
+
+```bash
+pip install .[tests]      # pytest, pytest-cov, PyYAML, vcrpy
+pytest                    # testpaths = ["tests"]; capture to a file for analysis
+```
+
+`src/conftest.py` puts `src/` on `sys.path` so imports resolve without a `src.` prefix. The SDK (`polyswarm_api`) must be installed too — in CI it's pulled from the SDK repo's branch archive (see [`05-sdk-contract.md`](./05-sdk-contract.md)); locally, install the SDK you're testing against (an editable checkout of the SDK works).
+
+## Style 1 — SDK-boundary mocks
+
+For commands whose behaviour is "call this SDK method, render the result," patch the method on the SDK client and assert the call + the rendered output. Example: `tests/field_property_test.py` patches `polyswarm_api.api.PolyswarmAPI.metadata_field_properties_{write,get,delete,list}` and drives `CliRunner`. This insulates the test from SDK transport internals — it survives SDK refactors as long as the method name/signature is stable.
+
+Use this style when the point of the test is the **command wiring + formatting**, not the wire shape.
+
+## Style 2 — VCR cassettes
+
+For end-to-end coverage (the CLI calling the SDK calling a recorded server), `tests/cli_test.py` uses `vcrpy`. Each test has two fixtures in `tests/vcr/`:
+
+- `tests/vcr/<name>.vcr` — the recorded HTTP interaction(s).
+- `tests/vcr/<name>.click` — the expected rendered CLI output (compared against `result.output`).
+
+The VCR object is built with the default request matcher (`method, scheme, host, port, path, query`) — it does **not** match on headers or body, so cassettes survive User-Agent changes and request-body relocation, and the `query` matcher compares params as a set (order-independent). Default `record_mode='once'`.
+
+Helpers in `cli_test.py`: `_run_cli(args)` invokes the command tree under a cassette; `_assert_text_result` / `_assert_json_result` compare `result.output` and the exit code against the `.click` fixture.
+
+### Re-recording a cassette
+
+```bash
+rm tests/vcr/<name>.vcr            # (and regenerate <name>.click from the new run)
+pytest tests/cli_test.py::<Class>::<test>   # records against whatever stack your env points at
+```
+
+Point your environment at a live e2e stack, run the test, and commit the freshly recorded `.vcr` (+ updated `.click`). The deletion is what makes VCR record.
+
+## What to test for a new command
+
+1. The command parses its arguments and calls the expected SDK method with the expected arguments.
+2. The result is rendered through the right formatter method, for both `--output-format text` and `json` where both matter.
+3. Error paths map to the right exit code (no-results → 1, partial → 3, internal/other → 2) — see [`01-architecture.md`](./01-architecture.md) §exit-code mapping.
+
+## Incremental — to be expanded
+
+This spec describes the harness as it stands. Not yet documented (add as the suite grows): a per-command coverage matrix, a documented "VCR-off against live e2e" CI job, and conventions for fixture/`.click` generation. See [`99-open-questions.md`](./99-open-questions.md).

--- a/specs/05-sdk-contract.md
+++ b/specs/05-sdk-contract.md
@@ -1,0 +1,82 @@
+# polyswarm-cli — SDK contract (CLI as a consumer of polyswarm-api)
+
+## Scope
+
+How the CLI depends on the `polyswarm-api` SDK: which parts of the SDK's public surface it consumes, the rules for consuming them correctly, how the two repos ship coordinated changes, and how the version pin is managed. This is the mirror image of the SDK's own `specs/05-downstream-contract.md` — read that for the authoritative list of what the SDK guarantees.
+
+## Invariants
+
+- **The CLI consumes only the SDK's public surface.** That means `polyswarm_api.api.PolyswarmAPI` (subclassed as `Polyswarm`), `polyswarm_api.resources`, `polyswarm_api.exceptions`, `polyswarm_api.settings`, and the documented power-user helpers on the client (`_single`, `session`). It does **not** reverse-engineer private internals or transport details.
+- **The SDK owns the wire; the CLI owns the UX.** If the CLI needs a new server capability, the SDK gets the method first (`AGENTS.md` §"When adding a command family", step 1).
+- **SDK + CLI changes that depend on each other ship as a pair.** The SDK PR opens first; the CLI PR links it under `## Requires` and must not merge before the SDK surface it needs is released / on the SDK's `develop` (CI installs the SDK from there — see below).
+- **The SDK version pin in `pyproject.toml` is the compatibility contract.** Floor it at the lowest SDK version that exposes every method/behaviour the CLI relies on.
+
+## What the CLI imports from the SDK
+
+| Import | Used for |
+|---|---|
+| `from polyswarm_api.api import PolyswarmAPI` | Base class of the `Polyswarm` wrapper (`src/polyswarm/polyswarm.py`). |
+| `from polyswarm_api import settings` | Defaults: `DEFAULT_SCAN_TIMEOUT`, `DEFAULT_REPORT_TIMEOUT`, etc. |
+| `from polyswarm_api import resources` | Result-parser classes for power-user calls (e.g. `resources.ArtifactInstance`); resource attributes the formatters read. |
+| `from polyswarm_api import exceptions as api_exceptions` | Caught in `ExceptionHandlingGroup` and `utils.parallel_executor` (`NoResultsException`, `NotFoundException`, `FailedInstanceException`, `PolyswarmException`). |
+| `from polyswarm_api.core import parse_isoformat` | Date rendering in `formatters/text.py`. |
+| `import polyswarm_api` (`__version__`) | `--api-version`. |
+
+All of the above are part of the SDK's documented public surface. If a future change needs something not on that list, that's a signal to add a method/export to the SDK rather than reach into internals.
+
+## Consuming the SDK correctly
+
+### Endpoint methods return generators — iterate them
+
+The SDK's search / list / paginated methods (`search`, `search_url`, `search_scans`, `search_by_metadata`, `search_by_ioc`, `iocs_by_hash`, `check_known_hosts`, `*_list`, `historical_results`, `live_feed`, `stream`, …) are **lazy generators**. Consume them by iteration:
+
+```python
+for item in api.iocs_by_hash(type, value):
+    output.ioc(item)
+```
+
+**Never** pass a generator to a singular formatter (`output.ioc(api.iocs_by_hash(...))` raises `'generator' object has no attribute …`), and never `len()` or index one. Single-resource methods (e.g. `report_get`, `sandbox_task_status`, `metadata_mapping`, `*_create`/`*_update`/`*_delete`) return one object — render those directly.
+
+Because the generators are **lazy**, calling one does no I/O and raises nothing until iterated. Code that runs SDK calls through a thread pool must consume the generator **inside the worker** so per-item exception handling fires where it's expected — this is why `utils.parallel_executor_iterable_results` materialises each generator inside the submitted callable (see `01-architecture.md`).
+
+### No-results signalling
+
+A search that the server answers `204 No Content` raises `NoResultsException` from the SDK **when the generator is iterated**. The CLI's `ExceptionHandlingGroup` maps that (and the CLI's own aggregate `NoResultsException` from `parallel_executor`) to exit code `1`. Don't swallow it in command code.
+
+### Execution helpers
+
+For the rare CLI-owned endpoint with no dedicated SDK method (e.g. the inline IP-analysis submit in `Polyswarm.submit_url`), build the request through the client's own helper rather than hand-rolling transport:
+
+```python
+return self._single(
+    {'method': 'POST', 'url': f'{self.uri}/instance/url', 'params': {...}, 'json': {...}},
+    result_parser=resources.ArtifactInstance,
+)
+```
+
+`_single` builds the request descriptor, executes it via `self.session`, and returns the parsed resource. Do **not** import `PolyswarmRequest` and call `.execute()`/`.result()` — those are not part of the supported surface.
+
+## Coordinated changes (paired PRs)
+
+When a CLI feature needs an SDK surface that doesn't exist yet:
+
+1. Land it in the SDK first (`polyswarm-api` PR, possibly preceded by an `artifact-index` change).
+2. Open the CLI PR with a `## Requires` section linking the SDK PR.
+3. The CLI PR must not merge until the SDK surface it depends on is on the SDK's `develop` (or released), because **CI installs the SDK from the SDK repo's branch archive** — `.gitlab-ci.yml` does `pip install …/$CI_COMMIT_BRANCH.zip || …/develop.zip`. A CLI branch with no matching SDK branch name falls back to the SDK's `develop` archive, so a CLI change that needs an unreleased SDK surface will fail CI until that surface is on the SDK's `develop` (or you temporarily point the archive ref at the SDK feature branch).
+
+## Version pin
+
+- The pin lives in `pyproject.toml` `dependencies` (`polyswarm_api>=…`). Floor it at the lowest SDK version exposing everything the CLI uses; cap it below the next known-incompatible major when one is anticipated.
+- The CLI is **sync-only** — it imports `polyswarm_api.api.PolyswarmAPI`, never `polyswarm_api.aio`. Don't add the `polyswarm_api[async]` extra.
+- Bumping the pin is a normal code change; bumping the CLI's *own* version is a release step (`AGENTS.md` §Gitflow). They're unrelated.
+
+## Worked example — the httpx SDK migration
+
+The SDK's move to an `httpx`-based, three-layer architecture (pure-dataclass `PolyswarmRequest`, session-based execution, lazy generators) removed several 3.x affordances the CLI had reached into:
+
+- `PolyswarmRequest(api, dict).execute().result()` → `self._single({...}, result_parser=…)`.
+- `ReportTask.download_report(...).result()` → `api.report_download(id, folder)`.
+- `output.ioc(api.iocs_by_hash(...))` (singular) → iterate the generator.
+- requests' exception names in the error handler → add the `httpx` leaf names.
+
+That migration is the canonical example of this spec's rules: consume generators by iteration, execute through `_single`/`session`, and ship the CLI change paired with the SDK release. (Tracked in the internal tracker; not named here because this repo is public.)

--- a/specs/99-open-questions.md
+++ b/specs/99-open-questions.md
@@ -1,0 +1,35 @@
+# Open Questions
+
+## Scope
+
+Known follow-ups and areas the `specs/` tree hasn't fully defined yet. This is the parking lot — each item is something a future PR will flesh out. Move an item out (into the relevant spec) once it's resolved. The specs are deliberately **incremental**; this file tracks where they're still seeds.
+
+## Command catalogue — per-subcommand detail
+
+**Status:** seed.
+
+[`02-commands.md`](./02-commands.md) maps each group to the SDK area it wraps, but doesn't enumerate per-subcommand arguments/options/behaviour. **Action:** as each command family is revised, document its non-obvious subcommands (flags, defaults, multi-arg fan-out semantics) in `02-commands.md`. The code is authoritative until then.
+
+## Formatter rendering rules
+
+**Status:** seed.
+
+[`03-formatters.md`](./03-formatters.md) documents the interface and selection, not the field-level rendering of each resource. **Action:** when a resource's text/JSON layout becomes contested or non-obvious, capture the intended layout there (so the reviewer can catch drift).
+
+## "VCR-off against live e2e" CI job
+
+**Status:** not implemented.
+
+The invariant in [`04-testing.md`](./04-testing.md) says the suite must pass against a live e2e stack with VCR off, but no CI job exercises that today (CI runs the cassette-backed suite). **Action:** decide whether to add a periodic VCR-off job and where it points.
+
+## SDK ↔ CLI version-coupling automation
+
+**Status:** manual.
+
+The SDK pin and the paired-PR `## Requires` convention ([`05-sdk-contract.md`](./05-sdk-contract.md)) are enforced by humans/review today. CI installs the SDK from the SDK repo's branch archive (`$CI_COMMIT_BRANCH.zip || develop.zip`), so a CLI change that needs an unreleased SDK surface fails until that surface is on the SDK's `develop`. **Action:** decide whether to make the coupling explicit (e.g. an env-overridable SDK ref for testing a CLI change against an SDK feature branch before it merges) rather than relying on the `develop.zip` fallback.
+
+## Wrapper vs. SDK boundary for orchestration
+
+**Status:** open.
+
+The `Polyswarm(PolyswarmAPI)` wrapper holds CLI-only orchestration (parallel fan-out, multi-step flows). Some of it (e.g. `submit_url`'s inline `/instance/url` endpoint) arguably belongs in the SDK so the CLI is a pure wrapper. **Action:** as the SDK grows methods that subsume wrapper logic, migrate the wrapper to call them and shrink the CLI-owned surface.


### PR DESCRIPTION
## TL;DR
- Reproduces the `polyswarm-api` agentic-context setup for `polyswarm-cli`: a **Claude Code Review** GitHub workflow, a `specs/` tree, and an `AGENTS.md` restructured around it.
- The workflow is a **verbatim copy** of polyswarm-api's — what localises the review to this repo is the `specs/` + `AGENTS.md`, not the workflow.
- `specs/` is **incremental**: accurate for what's defined today, seeded where it isn't, to be augmented as the CLI grows.

## Changes
- **`.github/workflows/claude-code-review.yml`** — auto-review on PR `opened`/`synchronize` via `anthropics/claude-code-action`. Byte-identical to polyswarm-api's; requires the `ANTHROPIC_API_KEY` repo/org secret.
- **`specs/`** — `00-overview`, `01-architecture`, `02-commands` *(seed)*, `03-formatters` *(seed)*, `04-testing`, `05-sdk-contract`, `99-open-questions`. Each opens with **Scope + Invariants** per the polyswarm-api convention. `05-sdk-contract.md` is the mirror of the SDK's downstream-contract spec — it captures how the CLI must consume the SDK (iterate generators, execute via `_single`/`session`, paired-PR/`## Requires` convention, version-pin coupling).
- **`AGENTS.md`** — adds a reading order + specs index, an architecture summary, a testing/VCR section, and generic commit/PR hygiene rules (conventional commits, no ticket refs on this public repo, no AI-attribution). Preserves the existing gitflow + companion-repo guidance. `CLAUDE.md` still symlinks to `AGENTS.md`.

## Notes
- GitHub runs the PR-review workflow from the **PR's base branch**, so landing this on `develop` (the default branch) is what makes the bot review develop-targeting PRs.
- The `ANTHROPIC_API_KEY` secret (repo or org) must be configured for the action to run.
