### PR TITLE
Render known-good binaries in text output

### DIFF
--- a/specs/03-formatters.md
+++ b/specs/03-formatters.md
@@ -38,3 +38,16 @@ Formatters don't set exit codes — that's `ExceptionHandlingGroup`'s job, by ex
 2. Implement it in `TextOutput` and `JSONOutput` (and the hash formatters if it carries hashes).
 3. Match the style of the existing labelled blocks for text output.
 4. Call it from the command (`output.<resource>(...)`), iterating if the SDK method returns a generator.
+
+## Known-good artifact instances
+
+`TextOutput.artifact_instance` special-cases a known-good binary: when the SDK
+resource exposes `known_good_sources` (the sorted flagging-feed names — see the
+SDK's `ArtifactInstance.known_good`), the **Detections** line reads
+"This artifact is a known-good binary (flagged by: …); it is not scanned." and
+the **Status** line reads "Known good", instead of the misleading
+"no engines responded — rescan now" a window-closed/no-assertion instance would
+otherwise get. The attribute is read with `getattr(..., None)` so a CLI running
+against an older SDK (without the field) renders exactly as before. `JSONOutput`
+needs no change — it dumps the resource's `.json`, which already carries the raw
+`known_good` array.

--- a/src/polyswarm/formatters/text.py
+++ b/src/polyswarm/formatters/text.py
@@ -77,7 +77,15 @@ class TextOutput(base.BaseOutput):
         if not instance.failed:
             output.append(self._white(f'Scan permalink: {instance.permalink}'))
 
-        if instance.community == 'stream':
+        # Defensive getattr: this attribute ships in the paired SDK release, but a
+        # CLI running against an older installed SDK won't have it (no AttributeError).
+        known_good_sources = getattr(instance, 'known_good_sources', None) or []
+
+        if known_good_sources and not instance.failed:
+            feeds = ', '.join(known_good_sources)
+            output.append(self._white(
+                f'Detections: This artifact is a known-good binary (flagged by: {feeds}); it is not scanned.'))
+        elif instance.community == 'stream':
             output.append(self._white('Detections: This artifact has not been scanned. You can trigger a scan now.'))
         elif len(instance.valid_assertions) == 0 and instance.window_closed and not instance.failed:
             output.append(self._white('Detections: No engines responded to this scan. You can trigger a rescan now.'))
@@ -112,6 +120,8 @@ class TextOutput(base.BaseOutput):
             output.append(self._red('Status: Failed'))
             if instance.failed_reason:
                 output.append(self._red(f'Failure Reason: {instance.failed_reason}'))
+        elif known_good_sources:
+            output.append(self._white('Status: Known good'))
         elif instance.window_closed:
             output.append(self._white('Status: Assertion window closed'))
         elif instance.community == 'stream':

--- a/tests/known_good_field_test.py
+++ b/tests/known_good_field_test.py
@@ -1,0 +1,53 @@
+"""Pure-unit rendering tests for the known_good field on an artifact instance.
+
+No CliRunner / VCR — these drive the text formatter directly with a constructed
+ArtifactInstance (the SDK resource), asserting that a known-good binary renders
+its flagging feeds and a "Known good" status instead of the misleading
+"no engines responded — rescan now" message, and that a normal instance is
+unchanged.
+"""
+import click
+from polyswarm_api import resources
+
+from polyswarm.formatters.text import TextOutput
+
+SHA = 'a' * 64
+
+
+def _instance(**overrides):
+    content = {
+        'sha256': SHA, 'md5': 'c' * 32, 'sha1': 'b' * 40,
+        'mimetype': 'application/x-dosexec', 'size': 68, 'extended_type': '',
+        'first_seen': '2020-01-01T00:00:00', 'upload_url': '', 'metadata': [],
+        'id': '111', 'community': 'gamma', 'assertions': [], 'votes': [],
+        'failed': False, 'window_closed': True, 'polyscore': None,
+    }
+    content.update(overrides)
+    return resources.ArtifactInstance(content)
+
+
+def _render(instance):
+    return click.unstyle('\n'.join(TextOutput(color=False).artifact_instance(instance, write=False)))
+
+
+class TestKnownGoodTextRendering:
+    def test_known_good_instance_renders_feeds_and_status(self):
+        feeds = [
+            {'tool': 'winget', 'tool_metadata': {}, 'created': '2026-06-11T00:00:00',
+             'updated': '2026-06-11T00:00:00'},
+            {'tool': 'nsrl', 'tool_metadata': {}, 'created': '2026-06-11T00:00:00',
+             'updated': '2026-06-11T00:00:00'},
+        ]
+        text = _render(_instance(known_good=feeds))
+        # Feeds are listed (sorted) and the status reflects known-good.
+        assert 'known-good binary (flagged by: nsrl, winget); it is not scanned.' in text
+        assert 'Status: Known good' in text
+        # A known-good binary must NOT be told to rescan / that no engines responded.
+        assert 'trigger a rescan' not in text
+
+    def test_normal_instance_unchanged(self):
+        text = _render(_instance())
+        assert 'known-good' not in text.lower()
+        assert 'Status: Known good' not in text
+        # The pre-existing window-closed rendering still applies.
+        assert 'Status: Assertion window closed' in text


### PR DESCRIPTION
## TL;DR

- The text formatter now renders a **known-good binary** specially: when the SDK resource exposes a non-empty `known_good_sources`, the **Detections** line reads "This artifact is a known-good binary (flagged by: …); it is not scanned." and the **Status** line reads "Known good".
- Replaces the misleading "no engines responded — rescan now" message a window-closed, no-assertion instance would otherwise show.
- Read defensively with `getattr(..., None)`, so a CLI running against an older SDK renders exactly as before. Non-known-good output is byte-for-byte unchanged; `JSONOutput` needs no change (it dumps `.json`, which already carries the raw `known_good` array).

## Tests

Pure-unit formatter tests: a known-good instance renders the sorted feed list + "Status: Known good" and no rescan prompt; a normal instance is unchanged (still "Status: Assertion window closed"). Full CLI suite green (74 passed) — no golden-output cassette shifts. Spec `03-formatters.md` updated in the same change set.

## Requires

- polyswarm-api PR #306 (adds `ArtifactInstance.known_good` / `known_good_sources`, the attribute this rendering reads). Backward-compatible via `getattr`, but the known-good rendering only activates once that SDK change is released.