### PR TITLE
feat: render "Known Good" for known-good-bypassed scans

### DIFF
--- a/specs/03-formatters.md
+++ b/specs/03-formatters.md
@@ -41,13 +41,23 @@ Formatters don't set exit codes — that's `ExceptionHandlingGroup`'s job, by ex
 
 ## Known-good artifact instances
 
-`TextOutput.artifact_instance` special-cases a known-good binary: when the SDK
-resource exposes `known_good_sources` (the sorted flagging-feed names — see the
-SDK's `ArtifactInstance.known_good`), the **Detections** line reads
-"This artifact is a known-good binary (flagged by: …); it is not scanned." and
-the **Status** line reads "Known good", instead of the misleading
-"no engines responded — rescan now" a window-closed/no-assertion instance would
-otherwise get. The attribute is read with `getattr(..., None)` so a CLI running
-against an older SDK (without the field) renders exactly as before. `JSONOutput`
-needs no change — it dumps the resource's `.json`, which already carries the raw
-`known_good` array.
+`TextOutput.artifact_instance` special-cases a known-good binary, rendering a
+**green** "Known Good" signal (a stronger benign signal than "clean") instead of
+the misleading "no engines responded — rescan now" a window-closed/no-assertion
+instance would otherwise get. It is gated by a single
+`is_known_good = (state == 'KNOWN_GOOD') or known_good_sources` flag:
+
+- **`state == 'KNOWN_GOOD'`** (the SDK's `ArtifactInstance.state`, the friendly
+  bounty-state name) is the reliable signal — it fires even for a scan-bypassed
+  instance that carries **no** feed metadata.
+- **`known_good_sources`** (the sorted flagging-feed names, from
+  `ArtifactInstance.known_good`) is the richer signal: when present, the
+  **Detections** line names the feeds ("…known-good binary (flagged by: …); it is
+  not scanned."); otherwise it reads "…is a known-good binary; it is not scanned."
+  It also keeps known-good rendering working against an older SDK that has the feed
+  list but not `.state`.
+
+The **Status** line reads "Known good" whenever `is_known_good`. Both attributes are
+read with `getattr(..., None)` so a CLI on an older SDK (missing either field)
+renders exactly as before. `JSONOutput` needs no change — it dumps the resource's
+`.json`, which already carries the raw `state` and `known_good` keys.

--- a/src/polyswarm/formatters/text.py
+++ b/src/polyswarm/formatters/text.py
@@ -77,14 +77,23 @@ class TextOutput(base.BaseOutput):
         if not instance.failed:
             output.append(self._white(f'Scan permalink: {instance.permalink}'))
 
-        # Defensive getattr: this attribute ships in the paired SDK release, but a
-        # CLI running against an older installed SDK won't have it (no AttributeError).
+        # Defensive getattr: these attributes ship in the paired SDK release, but a
+        # CLI running against an older installed SDK won't have them (no AttributeError).
         known_good_sources = getattr(instance, 'known_good_sources', None) or []
+        # A known-good binary is signalled by the bounty state (KNOWN_GOOD) — reliable
+        # even for a scan-bypassed instance with no feed metadata. known_good_sources
+        # (the flagging feeds) is the richer signal when present, and also covers an
+        # older SDK that lacks .state but still carries the feed list.
+        is_known_good = getattr(instance, 'state', None) == 'KNOWN_GOOD' or bool(known_good_sources)
 
-        if known_good_sources and not instance.failed:
-            feeds = ', '.join(known_good_sources)
-            output.append(self._white(
-                f'Detections: This artifact is a known-good binary (flagged by: {feeds}); it is not scanned.'))
+        if is_known_good and not instance.failed:
+            if known_good_sources:
+                feeds = ', '.join(known_good_sources)
+                output.append(self._green(
+                    f'Detections: This artifact is a known-good binary (flagged by: {feeds}); it is not scanned.'))
+            else:
+                output.append(self._green(
+                    'Detections: This artifact is a known-good binary; it is not scanned.'))
         elif instance.community == 'stream':
             output.append(self._white('Detections: This artifact has not been scanned. You can trigger a scan now.'))
         elif len(instance.valid_assertions) == 0 and instance.window_closed and not instance.failed:
@@ -120,8 +129,8 @@ class TextOutput(base.BaseOutput):
             output.append(self._red('Status: Failed'))
             if instance.failed_reason:
                 output.append(self._red(f'Failure Reason: {instance.failed_reason}'))
-        elif known_good_sources:
-            output.append(self._white('Status: Known good'))
+        elif is_known_good:
+            output.append(self._green('Status: Known good'))
         elif instance.window_closed:
             output.append(self._white('Status: Assertion window closed'))
         elif instance.community == 'stream':

--- a/tests/known_good_field_test.py
+++ b/tests/known_good_field_test.py
@@ -51,3 +51,30 @@ class TestKnownGoodTextRendering:
         assert 'Status: Known good' not in text
         # The pre-existing window-closed rendering still applies.
         assert 'Status: Assertion window closed' in text
+
+
+class TestKnownGoodStateRendering:
+    """A known-good-bypassed scan is signalled by state == 'KNOWN_GOOD' even when
+    the instance carries no flagging-feed metadata (no matching KnownGood)."""
+
+    def test_state_known_good_without_feeds(self):
+        text = _render(_instance(state='KNOWN_GOOD'))
+        # Rendered as known-good even with no feeds to attribute it to...
+        assert 'This artifact is a known-good binary; it is not scanned.' in text
+        assert 'Status: Known good' in text
+        # ...and never told to rescan / that no engines responded.
+        assert 'trigger a rescan' not in text
+        assert 'No engines responded' not in text
+
+    def test_state_known_good_with_feeds_lists_them(self):
+        feeds = [{'tool': 'winget', 'tool_metadata': {},
+                  'created': '2026-06-11T00:00:00', 'updated': '2026-06-11T00:00:00'}]
+        text = _render(_instance(state='KNOWN_GOOD', known_good=feeds))
+        # When feeds are present the richer message still lists them.
+        assert 'known-good binary (flagged by: winget); it is not scanned.' in text
+        assert 'Status: Known good' in text
+
+    def test_non_known_good_state_unchanged(self):
+        text = _render(_instance(state='SETTLED'))
+        assert 'known-good' not in text.lower()
+        assert 'Status: Known good' not in text


### PR DESCRIPTION
## TL;DR
- Render a **green "Known Good"** for a known-good-bypassed scan, driven off the SDK's new `ArtifactInstance.state == 'KNOWN_GOOD'`.
- Unified `is_known_good = (state == 'KNOWN_GOOD') or known_good_sources` gate: fires even when the bypassed instance carries **no** feed metadata; still lists the flagging feeds when present; backward-compatible with an older SDK that lacks `.state`.

## Context
A scan of a known-good sha is bypassed into the `KNOWN_GOOD` state but carries no feed metadata, so the prior feed-only rendering didn't fire and the CLI showed the misleading "no engines responded — rescan now". The SDK now exposes `.state`; this turns that into a clear "Known Good" signal (a stronger benign signal than "clean").

## Changes
- `src/polyswarm/formatters/text.py` — `artifact_instance` known-good rendering behind the single `is_known_good` flag, **green**; the Detections line names the feeds when `known_good_sources` is present, otherwise a plain known-good message. Both fields read via `getattr(..., None)`.
- `specs/03-formatters.md` — document the state-based rendering.
- **Deliberately kept** the `bounty_state == 6` "Stored" check reading `instance.json` (always present) rather than swapping it to `state == 'STORED'`, which would silently regress the "Stored" rendering against older servers/SDKs that don't send/parse `state`.

## Tests
- `tests/known_good_field_test.py::TestKnownGoodStateRendering` — `state == 'KNOWN_GOOD'` with no feeds → "Known Good" + no rescan; with feeds → lists them; a non-known-good state unchanged. `JSONOutput` unchanged (`state` passes through `.json`). Full suite green (100 passed).

## Requires
- https://github.com/polyswarm/polyswarm-api/pull/308 — the SDK's `ArtifactInstance.state` attribute.
