### PR TITLE
ci: parametrize CI template include via $CI_TEMPLATE

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - project: 'externalci/ci-image'
+  - project: '$CI_TEMPLATE'
     ref: master
     file: '.gitlab-ci-default.yaml'
 


### PR DESCRIPTION
Automated: point the shared-template `include:` at `$CI_TEMPLATE` so it resolves on both GitLab instances.